### PR TITLE
Allow (and ignore) booleans as children of components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Roact Changelog
 
 ## Current master
-* No changes
+* Support booleans in reconciliation ([#14](https://github.com/Roblox/roact/issues/14))
 
 ## 1.0.0 (TODO: Date)
 * Initial release

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -223,6 +223,10 @@ function Reconciler._reifyInternal(element, parent, key, context)
 			_reifiedChildren = reifiedChildren,
 			_rbx = target,
 		}
+	elseif typeof(element) == "boolean" then
+		-- Ignore booleans of either value
+		-- See https://github.com/Roblox/roact/issues/14
+		return nil
 	end
 
 	error(("Cannot reify invalid Roact element %q"):format(tostring(element)))

--- a/lib/Reconciler.spec.lua
+++ b/lib/Reconciler.spec.lua
@@ -1,0 +1,8 @@
+return function()
+    local Reconciler = require(script.Parent.Reconciler)
+
+    it("should reify booleans as nil", function()
+        local booleanReified = Reconciler.reify(false)
+        expect(booleanReified).to.never.be.ok()
+    end)
+end

--- a/lib/Reconciler.spec.lua
+++ b/lib/Reconciler.spec.lua
@@ -1,8 +1,8 @@
 return function()
-    local Reconciler = require(script.Parent.Reconciler)
+	local Reconciler = require(script.Parent.Reconciler)
 
-    it("should reify booleans as nil", function()
-        local booleanReified = Reconciler.reify(false)
-        expect(booleanReified).to.never.be.ok()
-    end)
+	it("should reify booleans as nil", function()
+		local booleanReified = Reconciler.reify(false)
+		expect(booleanReified).to.never.be.ok()
+	end)
 end


### PR DESCRIPTION
This closes #14. It allows for the children table passed to `Roact.createElement` to contain boolean values, which will be silently ignored. This enables the use of the pattern `condition and Roact.createElement` - without this patch, if `condition` is `false`, an error is thrown.