### PR TITLE
Throw a nicer error when failing to set primitive properties

### DIFF
--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -403,8 +403,7 @@ end
 --[[
 	Used in _setRbxProp to avoid creating a new closure for every property set.
 ]]
-
-local function _rawSet(rbx, key, value)
+local function set(rbx, key, value)
 	rbx[key] = value
 end
 
@@ -423,7 +422,7 @@ function Reconciler._setRbxProp(rbx, key, value, element)
 	if type(key) == "string" then
 		-- Regular property
 
-		local success, err = pcall(_rawSet, rbx, key, value)
+		local success, err = pcall(set, rbx, key, value)
 
 		if not success then
 			local source = element.source or "\n\t<Use Roact.DEBUG_ENABLE() to enable detailed tracebacks>\n"

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -396,7 +396,19 @@ function Reconciler._reconcilePrimitiveProps(fromElement, toElement, rbx)
 		-- Roblox does this check for normal values, but we have special
 		-- properties like events that warrant this.
 		if oldValue ~= newValue then
-			Reconciler._setRbxProp(rbx, key, newValue)
+			local success, err = pcall(Reconciler._setRbxProp, rbx, key, newValue)
+
+			if not success then
+				local source = toElement.source or "\n\t<Use Roact.DEBUG_ENABLE() to enable detailed tracebacks>\n"
+
+				local message = ("Failed to set property %s on primitive instance of class %s\n%s\n%s"):format(
+					key, rbx.ClassName,
+					err,
+					source
+				)
+
+				error(message, 0)
+			end
 		end
 	end
 
@@ -408,7 +420,19 @@ function Reconciler._reconcilePrimitiveProps(fromElement, toElement, rbx)
 			local oldValue = fromElement.props[key]
 
 			if oldValue ~= newValue then
-				Reconciler._setRbxProp(rbx, key, newValue)
+				local success, err = pcall(Reconciler._setRbxProp, rbx, key, newValue)
+
+				if not success then
+					local source = toElement.source or "\n\t<Use Roact.DEBUG_ENABLE() to enable detailed tracebacks>\n"
+
+					local message = ("Failed to set property %s on primitive instance of class %s\n%s\n%s"):format(
+						key, rbx.ClassName,
+						err,
+						source
+					)
+
+					error(message, 0)
+				end
 			end
 		end
 	end

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -26,6 +26,8 @@ local Core = require(script.Parent.Core)
 local getDefaultPropertyValue = require(script.Parent.getDefaultPropertyValue)
 local SingleEventManager = require(script.Parent.SingleEventManager)
 
+local DEFAULT_SOURCE = "\n\t<Use Roact.DEBUG_ENABLE() to enable detailed tracebacks>\n"
+
 local Reconciler = {}
 
 Reconciler._singleEventManager = SingleEventManager.new()
@@ -425,7 +427,7 @@ function Reconciler._setRbxProp(rbx, key, value, element)
 		local success, err = pcall(set, rbx, key, value)
 
 		if not success then
-			local source = element.source or "\n\t<Use Roact.DEBUG_ENABLE() to enable detailed tracebacks>\n"
+			local source = element.source or DEFAULT_SOURCE
 
 			local message = ("Failed to set property %s on primitive instance of class %s\n%s\n%s"):format(
 				key,
@@ -442,13 +444,28 @@ function Reconciler._setRbxProp(rbx, key, value, element)
 		if key.type == "event" then
 			Reconciler._singleEventManager:connect(rbx, key.name, value)
 		else
-			error(("Invalid special property type %q"):format(tostring(key.type)))
+			local source = element.source or DEFAULT_SOURCE
+
+			local message = ("Failed to set special property on primitive instance of class %s\nInvalid special property type %q\n%s"):format(
+				rbx.ClassName,
+				tostring(key.type),
+				source
+			)
+
+			error(message, 0)
 		end
 	elseif type(key) ~= "userdata" then
 		-- Userdata values are special markers, usually created by Symbol
 		-- They have no data attached other than being unique keys
 
-		error(("Properties of type %q are not supported"):format(type(key)))
+		local source = element.source or DEFAULT_SOURCE
+
+		local message = ("Properties with a key type of %q are not supported\n%s"):format(
+			type(key),
+			source
+		)
+
+		error(message, 0)
 	end
 end
 

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -446,6 +446,7 @@ function Reconciler._setRbxProp(rbx, key, value, element)
 		else
 			local source = element.source or DEFAULT_SOURCE
 
+			-- luacheck: ignore 6
 			local message = ("Failed to set special property on primitive instance of class %s\nInvalid special property type %q\n%s"):format(
 				rbx.ClassName,
 				tostring(key.type),


### PR DESCRIPTION
This fixes #19. It adds a prettier error message (with stack trace shown if `Roact.DEBUG_ENABLE` has been called; stack trace is drawn from the new element, not the old one) when reconciliation tries to set a primitive element property to an invalid type (or anything that causes `Reconciler._setRbxProp` to throw).

## Example stack trace
`Roact.DEBUG_ENABLE` has been called.
```
21:18:47.659 - Failed to set property Size on primitive instance of class Frame
21:18:47.660 - ReplicatedStorage.Roact.Reconciler:456: bad argument #3 to '?' (UDim2 expected, got number)
21:18:47.661 - 
21:18:47.661 - Stack Begin
21:18:47.662 - Script 'ReplicatedStorage.Roact.Core', Line 167 - field createElement
21:18:47.662 - Script 'Players.ProlificLexicon.PlayerGui.LocalScript', Line 13 - method render
21:18:47.664 - Script 'ReplicatedStorage.Roact.Component', Line 152 - method _forceUpdate
21:18:47.665 - Script 'ReplicatedStorage.Roact.Component', Line 127 - method _update
21:18:47.665 - Script 'ReplicatedStorage.Roact.Component', Line 114 - method setState
21:18:47.666 - Script 'Players.ProlificLexicon.PlayerGui.LocalScript', Line 21
21:18:47.666 - Stack End
21:18:47.667 - 
21:18:47.667 - Stack Begin
21:18:47.668 - Script 'ReplicatedStorage.Roact.Reconciler', Line 410 - field _reconcilePrimitiveProps
21:18:47.669 - Script 'ReplicatedStorage.Roact.Reconciler', Line 284 - field _reconcile
21:18:47.669 - Script 'ReplicatedStorage.Roact.Component', Line 156 - method _forceUpdate
21:18:47.670 - Script 'ReplicatedStorage.Roact.Component', Line 127 - method _update
21:18:47.670 - Script 'ReplicatedStorage.Roact.Component', Line 114 - method setState
21:18:47.671 - Script 'Players.ProlificLexicon.PlayerGui.LocalScript', Line 21
21:18:47.671 - Stack End
```

## Remarks
I'm not happy with the code duplication, but extracting it into a function will add another line to the stack trace - is that something that's acceptable if it means eliminating the code duplication?

There are no tests for this behavior, like most of Reconciler - I'm not sure if lemur supports type-checks on Roblox properties at the moment. If it does I'll write some tests for this.

I've suppressed the line-number reporting as much as possible (read: not a lot) by using `error(message, 0)`. This removes the initial line that reports the direct source of the error (`...Roact.Reconciler:line#`). Since this is an error raised by Roact, not a bug in Roact, I'm assuming we want to include as little information about Roact's internals to cut down on clutter.