### PR TITLE
setState sanity checking

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -43,6 +43,8 @@ function Component:extend(name)
 		local self = {}
 
 		self.props = props
+		-- Used for tracking whether the component is in a position to set state.
+		self._canSetState = false
 		self._context = {}
 
 		-- Shallow copy all context values from our parent element.
@@ -63,6 +65,9 @@ function Component:extend(name)
 		if not self.state then
 			self.state = {}
 		end
+
+		-- Now that state has definitely been set, we can now allow it to be changed.
+		self._canSetState = true
 
 		return self
 	end
@@ -101,6 +106,14 @@ end
 	current state object.
 ]]
 function Component:setState(partialState)
+	-- State cannot be set in any of the following places:
+	-- * During the component's init function
+	-- * During the component's render function
+	-- * After the component has been unmounted (or is in the process of unmounting, e.g. willUnmount)
+	if not self._canSetState then
+		error("State cannot be set at this point: are you setting state from an init, render, or willUnmount function?", 0)
+	end
+
 	local newState = {}
 
 	for key, value in pairs(self.state) do
@@ -149,7 +162,9 @@ function Component:_forceUpdate(newProps, newState)
 		self.state = newState
 	end
 
+	self._canSetState = false
 	local newChildElement = self:render()
+	self._canSetState = true
 
 	if self._handle._reified ~= nil then
 		-- We returned an element before, update it.

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -111,7 +111,7 @@ function Component:setState(partialState)
 	-- * During the component's render function
 	-- * After the component has been unmounted (or is in the process of unmounting, e.g. willUnmount)
 	if not self._canSetState then
-		error("State cannot be set at this point: are you setting state from an init, render, or willUnmount function?", 0)
+		error("setState cannot be used currently: are you calling setState from an init, render, or willUnmount function?", 0)
 	end
 
 	local newState = {}

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -175,7 +175,7 @@ return function()
 	end)
 
 	describe("setState", function()
-		it("should throw when called in init or render", function()
+		it("should throw when called in init", function()
 			local InitComponent = Component:extend("InitComponent")
 
 			function InitComponent:init()
@@ -184,6 +184,14 @@ return function()
 				})
 			end
 
+			local initElement = Core.createElement(InitComponent)
+
+			expect(function()
+				Reconciler.reify(initElement)
+			end).to.throw()
+		end)
+
+		it("should throw when called in render", function()
 			local RenderComponent = Component:extend("RenderComponent")
 
 			function RenderComponent:render()
@@ -192,12 +200,7 @@ return function()
 				})
 			end
 
-			local initElement = Core.createElement(InitComponent)
 			local renderElement = Core.createElement(RenderComponent)
-
-			expect(function()
-				Reconciler.reify(initElement)
-			end).to.throw()
 
 			expect(function()
 				Reconciler.reify(renderElement)

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -173,4 +173,56 @@ return function()
 
 		Reconciler.teardown(instance)
 	end)
+
+	describe("setState", function()
+		it("should throw when called in init or render", function()
+			local InitComponent = Component:extend("InitComponent")
+
+			function InitComponent:init()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local RenderComponent = Component:extend("RenderComponent")
+
+			function RenderComponent:render()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local initElement = Core.createElement(InitComponent)
+			local renderElement = Core.createElement(RenderComponent)
+
+			expect(function()
+				Reconciler.reify(initElement)
+			end).to.throw()
+
+			expect(function()
+				Reconciler.reify(renderElement)
+			end).to.throw()
+		end)
+
+		it("should throw when called in willUnmount", function()
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:render()
+				return nil
+			end
+
+			function TestComponent:willUnmount()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local element = Core.createElement(TestComponent)
+			local instance = Reconciler.reify(element)
+
+			expect(function()
+				Reconciler.teardown(instance)
+			end).to.throw()
+		end)
+	end)
 end

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -60,7 +60,7 @@ function Reconciler.teardown(instanceHandle)
 			Reconciler.teardown(instanceHandle._reified)
 		end
 	elseif Core.isStatefulElement(element) then
-        -- Stop the component from setting state in willUnmount or anywhere thereafter.
+		-- Stop the component from setting state in willUnmount or anywhere thereafter.
 		instanceHandle._instance._canSetState = false
 
 		-- Tell the component we're about to tear everything down.

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -60,6 +60,9 @@ function Reconciler.teardown(instanceHandle)
 			Reconciler.teardown(instanceHandle._reified)
 		end
 	elseif Core.isStatefulElement(element) then
+        -- Stop the component from setting state in willUnmount or anywhere thereafter.
+		instanceHandle._instance._canSetState = false
+
 		-- Tell the component we're about to tear everything down.
 		-- This gives it some notice!
 		if instanceHandle._instance.willUnmount then


### PR DESCRIPTION
This fixes #17. It throws an error when setState is called in the following locations:

* the `init` function of a component
* the `render` function of a component
* any point after the component begins unmounting, **including** within `willUnmount`

The error message:

```
State cannot be set at this point: are you setting state from an init, render, or willUnmount function?
```

Tests are included, yay!

This will probably have a merge conflict with #21; I'll fix it when it happens. This required an edit to `Reconciler` to set the flag to false just before unmounting the component.