### PR TITLE
More setState checks

### DIFF
--- a/docs/pages/lifecycle.md
+++ b/docs/pages/lifecycle.md
@@ -26,3 +26,5 @@ function TestComponent:willUnmount()
 	print("We're about to unmount!")
 end
 ```
+
+**Note:** If you are calling `setState` within `didMount` or `didUpdate`, make sure that you are not calling `setState` unconditionally. If `setState` is called every time `didMount` or `didUpdate` is called, you will cause a stack overflow error.

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -180,11 +180,11 @@ function Component:_forceUpdate(newProps, newState)
 		)
 	end
 
+	self._canSetState = true
+
 	if self.didUpdate then
 		self:didUpdate(oldProps, oldState)
 	end
-
-	self._canSetState = true
 end
 
 --[[
@@ -205,9 +205,7 @@ function Component:_reify(handle)
 	end
 
 	if self.didMount then
-		self._canSetState = false
 		self:didMount()
-		self._canSetState = true
 	end
 end
 

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -205,7 +205,9 @@ function Component:_reify(handle)
 	end
 
 	if self.didMount then
+		self._canSetState = false
 		self:didMount()
+		self._canSetState = true
 	end
 end
 

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -10,6 +10,14 @@ local Component = {}
 
 Component.__index = Component
 
+-- The error message that is thrown when setState is called in the wrong place.
+-- This is declared here to avoid really messy indentation.
+local INVALID_SETSTATE_MESSAGE = [[setState cannot be used currently, are you calling setState from any of:
+* the willUpdate or willUnmount lifecycle hooks
+* the init function
+* the render function
+* the shouldUpdate function]]
+
 --[[
 	Create a new Roact stateful component class.
 
@@ -108,7 +116,7 @@ end
 function Component:setState(partialState)
 	-- State cannot be set in any lifecycle hooks.
 	if not self._canSetState then
-		error("setState cannot be used currently: are you calling setState within a lifecycle hook?", 0)
+		error(INVALID_SETSTATE_MESSAGE, 0)
 	end
 
 	local newState = {}

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -12,7 +12,8 @@ Component.__index = Component
 
 -- The error message that is thrown when setState is called in the wrong place.
 -- This is declared here to avoid really messy indentation.
-local INVALID_SETSTATE_MESSAGE = [[setState cannot be used currently, are you calling setState from any of:
+local INVALID_SETSTATE_MESSAGE = [[
+setState cannot be used currently, are you calling setState from any of:
 * the willUpdate or willUnmount lifecycle hooks
 * the init function
 * the render function

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -275,6 +275,26 @@ return function()
 			end).to.throw()
 		end)
 
+		it("should throw when called in didMount", function()
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:render()
+				return nil
+			end
+
+			function TestComponent:didMount()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local element = Core.createElement(TestComponent)
+
+			expect(function()
+				Reconciler.reify(element)
+			end).to.throw()
+		end)
+
 		it("should throw when called in willUnmount", function()
 			local TestComponent = Component:extend("TestComponent")
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -268,54 +268,6 @@ return function()
 			end).to.throw()
 		end)
 
-		it("should throw when called in didUpdate", function()
-			local TestComponent = Component:extend("TestComponent")
-			local forceUpdate
-
-			function TestComponent:init()
-				forceUpdate = function()
-					self:_forceUpdate()
-				end
-			end
-
-			function TestComponent:render()
-				return nil
-			end
-
-			function TestComponent:didUpdate()
-				self:setState({
-					a = 1
-				})
-			end
-
-			local testElement = Core.createElement(TestComponent)
-
-			expect(function()
-				Reconciler.reify(testElement)
-				forceUpdate()
-			end).to.throw()
-		end)
-
-		it("should throw when called in didMount", function()
-			local TestComponent = Component:extend("TestComponent")
-
-			function TestComponent:render()
-				return nil
-			end
-
-			function TestComponent:didMount()
-				self:setState({
-					a = 1
-				})
-			end
-
-			local element = Core.createElement(TestComponent)
-
-			expect(function()
-				Reconciler.reify(element)
-			end).to.throw()
-		end)
-
 		it("should throw when called in willUnmount", function()
 			local TestComponent = Component:extend("TestComponent")
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -211,6 +211,70 @@ return function()
 			end).to.throw()
 		end)
 
+		it("should throw when called in shouldUpdate", function()
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:render()
+				return nil
+			end
+
+			function TestComponent:shouldUpdate()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local testElement = Core.createElement(TestComponent)
+
+			expect(function()
+				local handle = Reconciler.reify(testElement)
+				-- Something of a hack, but...
+				handle._instance:shouldUpdate({}, {})
+			end).to.throw()
+		end)
+
+		it("should throw when called in willUpdate", function()
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:render()
+				return nil
+			end
+
+			function TestComponent:willUpdate()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local testElement = Core.createElement(TestComponent)
+
+			expect(function()
+				local handle = Reconciler.reify(testElement)
+				handle._instance:_forceUpdate({}, {})
+			end).to.throw()
+		end)
+
+		it("should throw when called in didUpdate", function()
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:render()
+				return nil
+			end
+
+			function TestComponent:didUpdate()
+				self:setState({
+					a = 1
+				})
+			end
+
+			local testElement = Core.createElement(TestComponent)
+
+			expect(function()
+				local handle = Reconciler.reify(testElement)
+				handle._instance:_forceUpdate({}, {})
+			end).to.throw()
+		end)
+
 		it("should throw when called in willUnmount", function()
 			local TestComponent = Component:extend("TestComponent")
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -214,6 +214,14 @@ return function()
 		it("should throw when called in shouldUpdate", function()
 			local TestComponent = Component:extend("TestComponent")
 
+			local shouldUpdate
+
+			function TestComponent:init()
+				shouldUpdate = function()
+					self:shouldUpdate({}, {})
+				end
+			end
+
 			function TestComponent:render()
 				return nil
 			end
@@ -227,14 +235,20 @@ return function()
 			local testElement = Core.createElement(TestComponent)
 
 			expect(function()
-				local handle = Reconciler.reify(testElement)
-				-- Something of a hack, but...
-				handle._instance:shouldUpdate({}, {})
+				Reconciler.reify(testElement)
+				shouldUpdate()
 			end).to.throw()
 		end)
 
 		it("should throw when called in willUpdate", function()
 			local TestComponent = Component:extend("TestComponent")
+			local forceUpdate
+
+			function TestComponent:init()
+				forceUpdate = function()
+					self:_forceUpdate()
+				end
+			end
 
 			function TestComponent:render()
 				return nil
@@ -249,13 +263,20 @@ return function()
 			local testElement = Core.createElement(TestComponent)
 
 			expect(function()
-				local handle = Reconciler.reify(testElement)
-				handle._instance:_forceUpdate({}, {})
+				Reconciler.reify(testElement)
+				forceUpdate()
 			end).to.throw()
 		end)
 
 		it("should throw when called in didUpdate", function()
 			local TestComponent = Component:extend("TestComponent")
+			local forceUpdate
+
+			function TestComponent:init()
+				forceUpdate = function()
+					self:_forceUpdate()
+				end
+			end
 
 			function TestComponent:render()
 				return nil
@@ -270,8 +291,8 @@ return function()
 			local testElement = Core.createElement(TestComponent)
 
 			expect(function()
-				local handle = Reconciler.reify(testElement)
-				handle._instance:_forceUpdate({}, {})
+				Reconciler.reify(testElement)
+				forceUpdate()
 			end).to.throw()
 		end)
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -184,6 +184,10 @@ return function()
 				})
 			end
 
+			function InitComponent:render()
+				return nil
+			end
+
 			local initElement = Core.createElement(InitComponent)
 
 			expect(function()

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -214,11 +214,13 @@ return function()
 		it("should throw when called in shouldUpdate", function()
 			local TestComponent = Component:extend("TestComponent")
 
-			local shouldUpdate
+			local triggerTest
 
 			function TestComponent:init()
-				shouldUpdate = function()
-					self:shouldUpdate({}, {})
+				triggerTest = function()
+					self:setState({
+						a = 1
+					})
 				end
 			end
 
@@ -236,7 +238,7 @@ return function()
 
 			expect(function()
 				Reconciler.reify(testElement)
-				shouldUpdate()
+				triggerTest()
 			end).to.throw()
 		end)
 


### PR DESCRIPTION
This builds on the discussion from #23 after it was merged. It disallows calling `setState` in *all* lifecycle hooks, not just `willUnmount`. The error message has been changed to reflect this:

```
setState cannot be used currently: are you calling setState within a lifecycle hook?
```