### PR TITLE
Remove values from setState

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -5,6 +5,7 @@
 ]]
 
 local Reconciler = require(script.Parent.Reconciler)
+local Core = require(script.Parent.Core)
 
 local Component = {}
 
@@ -127,7 +128,11 @@ function Component:setState(partialState)
 	end
 
 	for key, value in pairs(partialState) do
-		newState[key] = value
+		if value == Core.None then
+			newState[key] = nil
+		else
+			newState[key] = value
+		end
 	end
 
 	self:_update(self.props, newState)

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -290,5 +290,41 @@ return function()
 				Reconciler.teardown(instance)
 			end).to.throw()
 		end)
+
+		it("should remove values from state when the value is Core.None", function()
+			local TestComponent = Component:extend("TestComponent")
+			local setStateCallback, getStateCallback
+
+			function TestComponent:init()
+				setStateCallback = function(newState)
+					self:setState(newState)
+				end
+
+				getStateCallback = function()
+					return self.state
+				end
+
+				self.state = {
+					value = 0
+				}
+			end
+
+			function TestComponent:render()
+				return nil
+			end
+
+			local element = Core.createElement(TestComponent)
+			local instance = Reconciler.reify(element)
+
+			expect(getStateCallback().value).to.equal(0)
+
+			setStateCallback({
+				value = Core.None
+			})
+
+			expect(getStateCallback().value).to.equal(nil)
+
+			Reconciler.teardown(instance)
+		end)
 	end)
 end

--- a/lib/Core.lua
+++ b/lib/Core.lua
@@ -19,7 +19,7 @@ Core.Ref = Symbol.named("Ref")
 -- Marker used to specify that a component is a Roact Portal.
 Core.Portal = Symbol.named("Portal")
 
--- Market used to specify that the value is nothing, because nil cannot be stored in tables.
+-- Marker used to specify that the value is nothing, because nil cannot be stored in tables.
 Core.None = Symbol.named("None")
 
 --[[

--- a/lib/Core.lua
+++ b/lib/Core.lua
@@ -19,6 +19,9 @@ Core.Ref = Symbol.named("Ref")
 -- Marker used to specify that a component is a Roact Portal.
 Core.Portal = Symbol.named("Portal")
 
+-- Market used to specify that the value is nothing, because nil cannot be stored in tables.
+Core.None = Symbol.named("None")
+
 --[[
 	Index into 'Event' to get a prop key for attaching to an event on a
 	Roblox Instance.


### PR DESCRIPTION
This fixes #30. It adds a `Roact.None` symbol that, when used in setState, will remove the key from the state.

Usage:
```lua
-- state already contains a value named "value"
self:setState({
    value = Roact.None,
})

-- state no longer contains "value"
```