### PR TITLE
Allow functions to be passed to setState

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -123,7 +123,7 @@ function Component:setState(partialState)
 
 	-- If the partial state is a function, invoke it to get the actual partial state.
 	if type(partialState) == "function" then
-		partialState = partialState(self.props, self.state)
+		partialState = partialState(self.state, self.props)
 	end
 
 	local newState = {}

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -121,6 +121,11 @@ function Component:setState(partialState)
 		error(INVALID_SETSTATE_MESSAGE, 0)
 	end
 
+	-- If the partial state is a function, invoke it to get the actual partial state.
+	if type(partialState) == "function" then
+		partialState = partialState(self.props, self.state)
+	end
+
 	local newState = {}
 
 	for key, value in pairs(self.state) do

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -329,7 +329,7 @@ return function()
 
 		it("should invoke functions to compute a partial state", function()
 			local TestComponent = Component:extend("TestComponent")
-			local setStateCallback, getStateCallback
+			local setStateCallback, getStateCallback, getPropsCallback
 
 			function TestComponent:init()
 				setStateCallback = function(newState)
@@ -338,6 +338,10 @@ return function()
 
 				getStateCallback = function()
 					return self.state
+				end
+
+				getPropsCallback = function()
+					return self.props
 				end
 
 				self.state = {
@@ -355,6 +359,9 @@ return function()
 			expect(getStateCallback().value).to.equal(0)
 
 			setStateCallback(function(state, props)
+				expect(state).to.equal(getStateCallback())
+				expect(props).to.equal(getPropsCallback())
+
 				return {
 					value = state.value + 1
 				}

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -326,5 +326,43 @@ return function()
 
 			Reconciler.teardown(instance)
 		end)
+
+		it("should invoke functions to compute a partial state", function()
+			local TestComponent = Component:extend("TestComponent")
+			local setStateCallback, getStateCallback
+
+			function TestComponent:init()
+				setStateCallback = function(newState)
+					self:setState(newState)
+				end
+
+				getStateCallback = function()
+					return self.state
+				end
+
+				self.state = {
+					value = 0
+				}
+			end
+
+			function TestComponent:render()
+				return nil
+			end
+
+			local element = Core.createElement(TestComponent)
+			local instance = Reconciler.reify(element)
+
+			expect(getStateCallback().value).to.equal(0)
+
+			setStateCallback(function(props, state)
+				return {
+					value = state.value + 1
+				}
+			end)
+
+			expect(getStateCallback().value).to.equal(1)
+
+			Reconciler.teardown(instance)
+		end)
 	end)
 end

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -354,7 +354,7 @@ return function()
 
 			expect(getStateCallback().value).to.equal(0)
 
-			setStateCallback(function(props, state)
+			setStateCallback(function(state, props)
 				return {
 					value = state.value + 1
 				}


### PR DESCRIPTION
This fixes #33. It allows `setState` to accept a function, which is called with the `props` and `state` tables. This function is expected to return a partial state, which is then used to update the component's state.