### PR TITLE
Add Reconciler.reconcile to the public API

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -193,7 +193,7 @@ function Component:_forceUpdate(newProps, newState)
 
 	if self._handle._reified ~= nil then
 		-- We returned an element before, update it.
-		self._handle._reified = Reconciler.reconcile(
+		self._handle._reified = Reconciler._reconcileInternal(
 			self._handle._reified,
 			newChildElement
 		)

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -193,7 +193,7 @@ function Component:_forceUpdate(newProps, newState)
 
 	if self._handle._reified ~= nil then
 		-- We returned an element before, update it.
-		self._handle._reified = Reconciler._reconcile(
+		self._handle._reified = Reconciler.reconcile(
 			self._handle._reified,
 			newChildElement
 		)

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -324,7 +324,7 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 
 		if instanceHandle._reified then
 			-- Transition from tree to tree, even if 'rendered' is nil
-			newChild = Reconciler.reconcile(instanceHandle._reified, rendered)
+			newChild = Reconciler._reconcileInternal(instanceHandle._reified, rendered)
 		elseif rendered then
 			-- Transition from nil to new tree
 			newChild = Reconciler._reifyInternal(
@@ -378,7 +378,7 @@ function Reconciler._reconcilePrimitiveChildren(instance, newElement)
 	for key, childInstance in pairs(instance._reifiedChildren) do
 		local childElement = elementChildren and elementChildren[key]
 
-		childInstance = Reconciler.reconcile(childInstance, childElement)
+		childInstance = Reconciler._reconcileInternal(childInstance, childElement)
 
 		instance._reifiedChildren[key] = childInstance
 	end

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -105,7 +105,7 @@ end
 		- `context`: Used to pass Roact context values down the tree
 
 	The structure created by this method is important to the functionality of
-	the _reconcile methods -- they depend on this structure being well-formed.
+	the reconciliation methods; they depend on this structure being well-formed.
 ]]
 function Reconciler._reifyInternal(element, parent, key, context)
 	if Core.isPrimitiveElement(element) then
@@ -226,10 +226,10 @@ end
 --[[
 	Applies the state given by newElement to an existing Roact instance.
 
-	_reconcile will return the instance that should be used. This instance can
+	reconcile will return the instance that should be used. This instance can
 	be different than the one that was passed in.
 ]]
-function Reconciler._reconcile(instanceHandle, newElement)
+function Reconciler.reconcile(instanceHandle, newElement)
 	local oldElement = instanceHandle._element
 
 	-- Instance was deleted!
@@ -291,7 +291,7 @@ function Reconciler._reconcile(instanceHandle, newElement)
 
 		if instanceHandle._reified then
 			-- Transition from tree to tree, even if 'rendered' is nil
-			newChild = Reconciler._reconcile(instanceHandle._reified, rendered)
+			newChild = Reconciler.reconcile(instanceHandle._reified, rendered)
 		elseif rendered then
 			-- Transition from nil to new tree
 			newChild = Reconciler._reifyInternal(
@@ -345,7 +345,7 @@ function Reconciler._reconcilePrimitiveChildren(instance, newElement)
 	for key, childInstance in pairs(instance._reifiedChildren) do
 		local childElement = elementChildren and elementChildren[key]
 
-		childInstance = Reconciler._reconcile(childInstance, childElement)
+		childInstance = Reconciler.reconcile(childInstance, childElement)
 
 		instance._reifiedChildren[key] = childInstance
 	end

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -1,9 +1,26 @@
 return function()
 	local Roact = require(script.Parent)
 
-	it("should load", function()
+	it("should load with all public APIs", function()
 		expect(Roact).to.be.ok()
-		expect(Roact.createElement).to.be.ok()
+
+		-- Public functions
+		expect(Roact.createElement).to.be.a("function")
+		expect(Roact.reify).to.be.a("function")
+		expect(Roact.reconcile).to.be.a("function")
+		expect(Roact.oneChild).to.be.a("function")
+		expect(Roact.isPrimitiveElement).to.be.a("function")
+		expect(Roact.isFunctionalElement).to.be.a("function")
+		expect(Roact.isStatefulElement).to.be.a("function")
+
+		-- Objects
+		expect(Roact.Component).to.be.ok()
+		expect(Roact.PureComponent).to.be.ok()
+		expect(Roact.Portal).to.be.ok()
+		expect(Roact.Children).to.be.ok()
+		expect(Roact.Event).to.be.ok()
+		expect(Roact.Ref).to.be.ok()
+		expect(Roact.None).to.be.ok()
 	end)
 
 	describe("Props", function()


### PR DESCRIPTION
Closes #32.

This addresses one usability issue of Roact related to updating components without having to manually expose values like `setState`.

The new API has been an internal API for awhile, and works like this:

```lua
local handle = Roact.reify(Roact.createElement("StringValue", {
    Value = "Hello",
}))

-- Previously, we were now stuck with this element and could only tear it down.
-- Now, we can modify it with Roact.reconcile:
handle = Roact.reconcile(handle, Roact.createElement("StringValue", {
    Value = "World",
}))
```

One interesting gotcha about the API is that it *takes ownership* of the handle you pass in, and has the potential to return a new one. That means that `reconcile` is free to `teardown` the entire tree that you pass it and construct a new one.

An example that gets a lot simpler is our equivalent of React's [ticking clock intro example](https://reactjs.org/docs/rendering-elements.html#updating-the-rendered-element):

```lua
local function content()
    return Roact.createElement("TextLabel", {
        Text = "The current time is " .. time(),
    })
end

local handle = Roact.reify(content(), ScreenGui)

while true do
    wait(1)
    handle = Roact.reconcile(handle, content())
end
```

I'll need to do a pass over the WIP documentation to recommend using this as the introductory technique for getting change. It's also useful when embedding Roact inside non-Roact components, and affords you more flexibility to own state outside the Roact tree.