### PR TITLE
Remove is*Element functions

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -65,24 +65,3 @@ Given a dictionary of children, returns a single child element.
 If `children` contains more than one child, `oneChild` function will throw an error. This is intended to denote an error when using the component using `oneChild`.
 
 If `children` is `nil` or contains no children, `oneChild` will return `nil`.
-
-### Roact.isPrimitiveElement
-```
-Roact.isPrimitveElement(element) -> bool
-```
-
-Determines whether the given `element` is primtive. These elements are created with a string parameter to `createElement` and represent a Roblox instance.
-
-### Roact.isFunctionalElement
-```
-Roact.isFunctionalElement(element) -> bool
-```
-
-Determines whether the given `element` is functional. These elements are created with a function parameter to `createElement` and represent a stateless Roact component.
-
-### Roact.isStatefulElement
-```
-Roact.isStatefulElement(element) -> bool
-```
-
-Determines whether the given `element` is stateful. These elements are created with a table parameter to `createElement` and represent a *potentially* stateful Roact component.

--- a/lib/Core.lua
+++ b/lib/Core.lua
@@ -60,39 +60,6 @@ function Core.oneChild(children)
 end
 
 --[[
-	Is this element backed by a Roblox instance directly?
-]]
-function Core.isPrimitiveElement(element)
-	if type(element) ~= "table" then
-		return false
-	end
-
-	return type(element.type) == "string"
-end
-
---[[
-	Is this element defined by a pure function?
-]]
-function Core.isFunctionalElement(element)
-	if type(element) ~= "table" then
-		return false
-	end
-
-	return type(element.type) == "function"
-end
-
---[[
-	Is this element defined by a component class?
-]]
-function Core.isStatefulElement(element)
-	if type(element) ~= "table" then
-		return false
-	end
-
-	return type(element.type) == "table"
-end
-
---[[
 	Creates a new Roact element of the given type.
 
 	Does not create any concrete objects.

--- a/lib/Core.spec.lua
+++ b/lib/Core.spec.lua
@@ -6,8 +6,6 @@ return function()
 			local element = Core.createElement("Frame")
 
 			expect(element).to.be.ok()
-
-			expect(Core.isPrimitiveElement(element)).to.equal(true)
 		end)
 
 		it("should create new functional elements", function()
@@ -15,16 +13,12 @@ return function()
 			end)
 
 			expect(element).to.be.ok()
-
-			expect(Core.isFunctionalElement(element)).to.equal(true)
 		end)
 
 		it("should create new stateful components", function()
 			local element = Core.createElement({})
 
 			expect(element).to.be.ok()
-
-			expect(Core.isStatefulElement(element)).to.equal(true)
 		end)
 	end)
 

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -9,9 +9,6 @@ return function()
 		expect(Roact.reify).to.be.a("function")
 		expect(Roact.reconcile).to.be.a("function")
 		expect(Roact.oneChild).to.be.a("function")
-		expect(Roact.isPrimitiveElement).to.be.a("function")
-		expect(Roact.isFunctionalElement).to.be.a("function")
-		expect(Roact.isStatefulElement).to.be.a("function")
 
 		-- Objects
 		expect(Roact.Component).to.be.ok()


### PR DESCRIPTION
Fixes #45. Moves the various element-type determining functions into `Reconciler` and removes them from the public API.