### PR TITLE
Add getDerivedStateFromProps

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -191,12 +191,15 @@ function Component:_forceUpdate(newProps, newState)
 	-- Get the class - getDerivedStateFromProps is static.
 	local class = getmetatable(self)
 
-	if class.getDerivedStateFromProps then
-		local derivedState = class.getDerivedStateFromProps(newProps, newState or self.state)
+	-- Only update if newProps are given!
+	if newProps then
+		if class.getDerivedStateFromProps then
+			local derivedState = class.getDerivedStateFromProps(newProps, newState or self.state)
 
-		-- getDerivedStateFromProps can return nil if no changes are necessary.
-		if derivedState ~= nil then
-			newState = mergeState(newState or self.state, derivedState)
+			-- getDerivedStateFromProps can return nil if no changes are necessary.
+			if derivedState ~= nil then
+				newState = mergeState(newState or self.state, derivedState)
+			end
 		end
 	end
 

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -20,6 +20,24 @@ setState cannot be used currently, are you calling setState from any of:
 * the render function
 * the shouldUpdate function]]
 
+local function mergeState(currentState, partialState)
+	local newState = {}
+
+	for key, value in pairs(currentState) do
+		newState[key] = value
+	end
+
+	for key, value in pairs(partialState) do
+		if value == Core.None then
+			newState[key] = nil
+		else
+			newState[key] = value
+		end
+	end
+
+	return newState
+end
+
 --[[
 	Create a new Roact stateful component class.
 
@@ -74,6 +92,14 @@ function Component:extend(name)
 		-- The user constructer might not set state, so we can.
 		if not self.state then
 			self.state = {}
+		end
+
+		if class.getDerivedStateFromProps then
+			local partialState = class.getDerivedStateFromProps(props, self.state)
+
+			if partialState then
+				self.state = mergeState(self.state, partialState)
+			end
 		end
 
 		-- Now that state has definitely been set, we can now allow it to be changed.
@@ -133,20 +159,7 @@ function Component:setState(partialState)
 		partialState = partialState(self.state, self.props)
 	end
 
-	local newState = {}
-
-	for key, value in pairs(self.state) do
-		newState[key] = value
-	end
-
-	for key, value in pairs(partialState) do
-		if value == Core.None then
-			newState[key] = nil
-		else
-			newState[key] = value
-		end
-	end
-
+	local newState = mergeState(self.state, partialState)
 	self:_update(self.props, newState)
 end
 
@@ -173,6 +186,19 @@ end
 ]]
 function Component:_forceUpdate(newProps, newState)
 	self._canSetState = false
+
+	-- Compute new derived state.
+	-- Get the class - getDerivedStateFromProps is static.
+	local class = getmetatable(self)
+
+	if class.getDerivedStateFromProps then
+		local derivedState = class.getDerivedStateFromProps(newProps, newState or self.state)
+
+		-- getDerivedStateFromProps can return nil if no changes are necessary.
+		if derivedState ~= nil then
+			newState = mergeState(newState or self.state, derivedState)
+		end
+	end
 
 	if self.willUpdate then
 		self:willUpdate(newProps or self.props, newState or self.state)

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -177,74 +177,43 @@ return function()
 		Reconciler.teardown(instance)
 	end)
 
-	describe("getDerivedStateFromProps", function()
-		it("should be called when a component is initialized", function()
-			local TestComponent = Component:extend("TestComponent")
-			local getStateCallback
+	it("should call getDerivedStateFromProps appropriately", function()
+		local TestComponent = Component:extend("TestComponent")
+		local getStateCallback
 
-			function TestComponent.getDerivedStateFromProps(newProps, oldState)
-				return {
-					visible = newProps.visible
-				}
+		function TestComponent.getDerivedStateFromProps(newProps, oldState)
+			return {
+				visible = newProps.visible
+			}
+		end
+
+		function TestComponent:init(props)
+			self.state = {
+				visible = false
+			}
+
+			getStateCallback = function()
+				return self.state
 			end
+		end
 
-			function TestComponent:init(props)
-				self.state = {
-					visible = false
-				}
+		function TestComponent:render() end
 
-				getStateCallback = function()
-					return self.state
-				end
-			end
+		local handle = Reconciler.reify(Core.createElement(TestComponent, {
+			visible = true
+		}))
 
-			function TestComponent:render() end
+		local state = getStateCallback()
+		expect(state.visible).to.equal(true)
 
-			local handle = Reconciler.reify(Core.createElement(TestComponent, {
-				visible = true
-			}))
+		handle = Reconciler.reconcile(handle, Core.createElement(TestComponent, {
+			visible = 123
+		}))
 
-			local state = getStateCallback()
-			expect(state.visible).to.equal(true)
+		state = getStateCallback()
+		expect(state.visible).to.equal(123)
 
-			Reconciler.teardown(handle)
-		end)
-
-		it("should be called on property updates", function()
-			local TestComponent = Component:extend("TestComponent")
-			local getStateCallback
-
-			function TestComponent.getDerivedStateFromProps(newProps, oldState)
-				return {
-					visible = newProps.visible
-				}
-			end
-
-			function TestComponent:init(props)
-				self.state = {
-					visible = false
-				}
-
-				getStateCallback = function()
-					return self.state
-				end
-			end
-
-			function TestComponent:render() end
-
-			local handle = Reconciler.reify(Core.createElement(TestComponent, {
-				visible = true
-			}))
-
-			Reconciler.reconcile(handle, Core.createElement(TestComponent, {
-				visible = 123,
-			}))
-
-			local state = getStateCallback()
-			expect(state.visible).to.equal(123)
-
-			Reconciler.teardown(handle)
-		end)
+		Reconciler.teardown(handle)
 	end)
 
 	describe("setState", function()

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -177,6 +177,76 @@ return function()
 		Reconciler.teardown(instance)
 	end)
 
+	describe("getDerivedStateFromProps", function()
+		it("should be called when a component is initialized", function()
+			local TestComponent = Component:extend("TestComponent")
+			local getStateCallback
+
+			function TestComponent.getDerivedStateFromProps(newProps, oldState)
+				return {
+					visible = newProps.visible
+				}
+			end
+
+			function TestComponent:init(props)
+				self.state = {
+					visible = false
+				}
+
+				getStateCallback = function()
+					return self.state
+				end
+			end
+
+			function TestComponent:render() end
+
+			local handle = Reconciler.reify(Core.createElement(TestComponent, {
+				visible = true
+			}))
+
+			local state = getStateCallback()
+			expect(state.visible).to.equal(true)
+
+			Reconciler.teardown(handle)
+		end)
+
+		it("should be called on property updates", function()
+			local TestComponent = Component:extend("TestComponent")
+			local getStateCallback
+
+			function TestComponent.getDerivedStateFromProps(newProps, oldState)
+				return {
+					visible = newProps.visible
+				}
+			end
+
+			function TestComponent:init(props)
+				self.state = {
+					visible = false
+				}
+
+				getStateCallback = function()
+					return self.state
+				end
+			end
+
+			function TestComponent:render() end
+
+			local handle = Reconciler.reify(Core.createElement(TestComponent, {
+				visible = true
+			}))
+
+			Reconciler.reconcile(handle, Core.createElement(TestComponent, {
+				visible = 123,
+			}))
+
+			local state = getStateCallback()
+			expect(state.visible).to.equal(123)
+
+			Reconciler.teardown(handle)
+		end)
+	end)
+
 	describe("setState", function()
 		it("should throw when called in init", function()
 			local InitComponent = Component:extend("InitComponent")


### PR DESCRIPTION
Fixes #53.

Adds a static class function, `getDerivedStateFromProps`, that is invoked when a component instance is created and when properties change. This function receives two arguments: `newProps`, the new properties table, and `currentState`, the component's current state (note that in cases where rendering causes both properties and state to change, `currentState` will equal the new state - I'm not sure if this happens in practice).

`getDerivedStateFromProps` may return either a table or `nil`; if it returns a table, the table is merged into the state without triggering another re-render. This is called before any lifecycle hooks invoke, including `willUpdate`.