### PR TITLE
Component benchmarks

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -14,7 +14,7 @@ local invalidSetStateMessages = require(script.Parent.invalidSetStateMessages)
 local Component = {}
 
 -- Locally cache tick so we can minimize impact of calling it for instrumentation
-local l_tick = tick
+local tick = tick
 
 Component.__index = Component
 
@@ -191,10 +191,10 @@ function Component:_update(newProps, newState)
 	local doUpdate
 	if GlobalConfig.getValue("shouldUpdateInstrumentation") then
 		-- Start timing
-		local time = l_tick()
+		local time = tick()
 		doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
 		-- Finish timing
-		time = l_tick() - time
+		time = tick() - time
 		-- Log result
 		Instrumentation.logShouldUpdate(self._handle, doUpdate, time)
 	else
@@ -252,10 +252,10 @@ function Component:_forceUpdate(newProps, newState)
 	local newChildElement
 	if GlobalConfig.getValue("renderInstrumentation") then
 		-- Start timing
-		local time = l_tick()
+		local time = tick()
 		newChildElement = self:render()
 		-- End timing
-		time = l_tick() - time
+		time = tick() - time
 		-- Log result
 		Instrumentation.logRenderTime(self._handle, time)
 	else
@@ -299,10 +299,10 @@ function Component:_reify(handle)
 	local virtualTree
 	if GlobalConfig.getValue("renderInstrumentation") then
 		-- Start timing
-		local time = l_tick()
+		local time = tick()
 		virtualTree = self:render()
 		-- End timing
-		time = l_tick() - time
+		time = tick() - time
 		-- Log result
 		Instrumentation.logRenderTime(self._handle, time)
 	else

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -187,9 +187,8 @@ end
 function Component:_update(newProps, newState)
 	self._setStateBlockedReason = "shouldUpdate"
 
-	-- TODO: Encapsulate the instrumentation more gracefully
 	local doUpdate
-	if GlobalConfig.getValue("shouldUpdateInstrumentation") then
+	if GlobalConfig.getValue("componentInstrumentation") then
 		-- Start timing
 		local time = tick()
 		doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
@@ -248,9 +247,9 @@ function Component:_forceUpdate(newProps, newState)
 	end
 
 	self._setStateBlockedReason = "render"
-	-- TODO: Encapsulate the instrumentation more gracefully
+
 	local newChildElement
-	if GlobalConfig.getValue("renderInstrumentation") then
+	if GlobalConfig.getValue("componentInstrumentation") then
 		-- Start timing
 		local time = tick()
 		newChildElement = self:render()
@@ -261,6 +260,7 @@ function Component:_forceUpdate(newProps, newState)
 	else
 		newChildElement = self:render()
 	end
+
 	self._setStateBlockedReason = nil
 
 	self._setStateBlockedReason = "reconcile"
@@ -295,9 +295,8 @@ function Component:_reify(handle)
 
 	self._setStateBlockedReason = "render"
 
-	-- TODO: Encapsulate the instrumentation more gracefully
 	local virtualTree
-	if GlobalConfig.getValue("renderInstrumentation") then
+	if GlobalConfig.getValue("componentInstrumentation") then
 		-- Start timing
 		local time = tick()
 		virtualTree = self:render()

--- a/lib/Config.lua
+++ b/lib/Config.lua
@@ -16,6 +16,10 @@
 local defaultConfig = {
 	-- Enables storage of `debug.traceback()` values on elements for debugging.
 	["elementTracing"] = false,
+	-- Enables instrumentation of shouldUpdate
+	["shouldUpdateInstrumentation"] = false,
+	-- Enables instrumentation of rendering
+	["renderInstrumentation"] = false,
 }
 
 -- Build a list of valid configuration values up for debug messages.

--- a/lib/Config.lua
+++ b/lib/Config.lua
@@ -16,10 +16,8 @@
 local defaultConfig = {
 	-- Enables storage of `debug.traceback()` values on elements for debugging.
 	["elementTracing"] = false,
-	-- Enables instrumentation of shouldUpdate
-	["shouldUpdateInstrumentation"] = false,
-	-- Enables instrumentation of rendering
-	["renderInstrumentation"] = false,
+	-- Enables instrumentation of shouldUpdate and render methods for Roact components
+	["componentInstrumentation"] = false,
 }
 
 -- Build a list of valid configuration values up for debug messages.

--- a/lib/Instrumentation.lua
+++ b/lib/Instrumentation.lua
@@ -52,16 +52,16 @@ end
 	Logs the time taken and resulting value of a Component's shouldUpdate function
 ]]
 function Instrumentation.logShouldUpdate(handle, updateNeeded, shouldUpdateTime)
-	-- Make sure entry exists in stats object
+	-- Grab or create associated entry in stats table
 	local statEntry = getStatEntry(handle)
 	if statEntry then
 		-- Increment the total number of times update was invoked
 		statEntry.updateReqCount = statEntry.updateReqCount + 1
 
-		-- Increment total number of times shouldUpdate returned true (when applicable)
+		-- Increment (when applicable) total number of times shouldUpdate returned true
 		statEntry.didUpdateCount = statEntry.didUpdateCount + (updateNeeded and 1 or 0)
 
-		-- Add time spent checking if an update is needed to total time
+		-- Add time spent checking if an update is needed (in millis) to total time
 		statEntry.shouldUpdateTime = statEntry.shouldUpdateTime + shouldUpdateTime * 1000
 	end
 end
@@ -70,7 +70,7 @@ end
 	Logs the time taken value of a Component's render function
 ]]
 function Instrumentation.logRenderTime(handle, renderTime)
-	-- Make sure entry exists in stats object
+	-- Grab or create associated entry in stats table
 	local statEntry = getStatEntry(handle)
 	if statEntry then
 		-- Increment total render count

--- a/lib/Instrumentation.lua
+++ b/lib/Instrumentation.lua
@@ -1,0 +1,183 @@
+local GlobalConfig = require(script.Parent.GlobalConfig)
+
+local Instrumentation = {}
+
+local ComponentStats = {}
+-- Tracks HELLA stats, including:
+	-- Recorded stats:
+		-- Render count by component
+		-- Update request count by component
+		-- Actual update count by component
+		-- shouldUpdate returned true count by component
+		-- Time taken to run shouldUpdate
+		-- Time taken to render by component
+	-- Derived stats:
+		-- Average render time by component
+		-- Percent of total render time by component
+		-- Average shouldUpdate time by component
+		-- Percent of time shouldUpdate returns true
+		-- Percent of total shouldUpdate time by component
+
+local function valuesByStat(t, f)
+	local a = {}
+	for _, obj in pairs(t) do table.insert(a, obj) end
+	table.sort(a, f)
+	local i = 0      -- iterator variable
+	local iter = function ()   -- iterator function
+		i = i + 1
+		if a[i] == nil then
+			return nil
+		else
+			return a[i]
+		end
+	end
+	return iter
+end
+
+local function getStatEntry(handle)
+	local name
+	if handle and handle._element and handle._element.component then
+		name = tostring(handle._element.component)
+	else
+		warn("Component name not valid for " .. tostring(handle._key))
+		return nil
+	end
+	local entry = ComponentStats[name]
+	if not entry then
+		-- Use shortened name for convenience; 
+		local shortName = name:gsub("Connection","Conn")
+		shortName = shortName:gsub("Localize","Loc")
+		shortName = shortName:gsub("FitChildren","FitCh")
+		entry = {
+			-- store semi-redundant name field for easier sorting
+			component = shortName,
+			-- update requests
+			updateReqCount = 0,
+			-- actual updates
+			didUpdateCount = 0,
+			-- time spent in shouldUpdate
+			shouldUpdateTime = 0,
+			-- number of renders
+			renderCount = 0,
+			-- total render time spent
+			renderTime = 0,
+		}
+		ComponentStats[name] = entry
+	end
+
+	return entry
+end
+
+function Instrumentation.logShouldUpdate(handle, updateNeeded, shouldUpdateTime)
+	-- Make sure entry exists in stats object
+	local statEntry = getStatEntry(handle)
+	if statEntry then
+		-- Record result
+		statEntry.updateReqCount = statEntry.updateReqCount + 1
+		statEntry.didUpdateCount = statEntry.didUpdateCount + (updateNeeded and 1 or 0)
+		statEntry.shouldUpdateTime = statEntry.shouldUpdateTime + shouldUpdateTime * 1000
+	end
+end
+
+function Instrumentation.logRenderTime(handle, renderTime)
+	-- Make sure entry exists in stats object
+	local statEntry = getStatEntry(handle)
+	if statEntry then
+		-- Add the result to the collected stats
+		statEntry.renderCount = statEntry.renderCount + 1
+		-- Render time should be in millis
+		statEntry.renderTime = statEntry.renderTime + renderTime * 1000
+	end
+end
+
+function Instrumentation.printStats(sortBy)
+	sortBy = sortBy or "component"
+
+	local trackUpdates = GlobalConfig.getValue("shouldUpdateInstrumentation")
+	local trackRenders = GlobalConfig.getValue("renderInstrumentation")
+
+	if not trackUpdates and not trackRenders then
+		print("No stats are being tracked!  Enable with Roact.setConfig({...})")
+		return
+	end
+
+	local totalRenderTime, totalShouldUpdateTime = 0, 0
+
+	-- For each of the tracked stats, aggregate them into overall stats
+	for _, stat in pairs(ComponentStats) do
+		totalRenderTime = totalRenderTime + stat.renderTime
+		totalShouldUpdateTime = totalShouldUpdateTime + stat.shouldUpdateTime
+	end
+
+	-- Get derived stats
+	for _, stat in pairs(ComponentStats) do
+		stat.avgRenderTime = stat.renderTime / stat.renderCount
+		stat.avgShouldUpdateTime = (stat.updateReqCount > 0) and (stat.shouldUpdateTime / stat.updateReqCount) or 0
+		stat.renderPct = stat.renderTime / totalRenderTime * 100
+		stat.updateFreq = (stat.updateReqCount > 0) and (stat.didUpdateCount / stat.updateReqCount * 100) or 0
+		stat.updatePct = stat.shouldUpdateTime / totalShouldUpdateTime * 100
+	end
+
+	-- Set up sort function based on specified stat
+	local compare = function(a, b)
+		return a[sortBy] < b[sortBy]
+	end
+
+	-- Print column headers
+	local colHeaders = ("%-30s"):format("Component Name")
+	if trackUpdates then
+		colHeaders = colHeaders .. (
+			"%-12s%-12s%-12s%-12s%-12s"
+		):format(
+			"Update Reqs",
+			"Updates",
+			"Avg Time",
+			"Update %",
+			"U Time %"
+		)
+	end
+	if trackRenders then
+		colHeaders = colHeaders .. (
+			"%-12s%-12s%-12s"
+		):format(
+			"Renders",
+			"Avg Time",
+			"R Time %"
+		)
+	end
+	print(colHeaders)
+
+	-- Print stat rows
+	for stat in valuesByStat(ComponentStats, compare) do
+		local statsRow = ("%-30s"):format(stat.component)
+		if trackUpdates then
+			statsRow = statsRow .. (
+				"%-12d%-12d%-12.3f%-12.3f%-12.3f"
+			):format(
+				stat.updateReqCount,
+				stat.didUpdateCount,
+				stat.avgShouldUpdateTime,
+				stat.updateFreq,
+				stat.updatePct
+			)
+		end
+		if trackRenders then
+			statsRow = statsRow .. (
+				"%-12d%-12.3f%-12.3f"
+			):format(
+				stat.renderCount,
+				stat.avgRenderTime,
+				stat.renderPct
+			)
+		end
+		print(statsRow)
+	end
+	if trackUpdates then
+		print(("Total time shouldUpdating: %.2fms"):format(totalShouldUpdateTime))
+	end
+	if trackRenders then
+		print(("Total time rendering: %.2fms"):format(totalRenderTime))
+	end
+end
+
+return Instrumentation

--- a/lib/Instrumentation.spec.lua
+++ b/lib/Instrumentation.spec.lua
@@ -1,0 +1,80 @@
+return function()
+	local Component = require(script.Parent.PureComponent)
+	local Core = require(script.Parent.Core)
+	local GlobalConfig = require(script.Parent.GlobalConfig)
+	local Instrumentation = require(script.Parent.Instrumentation)
+	local Reconciler = require(script.Parent.Reconciler)
+
+	it("should count and time renders when enabled", function()
+		GlobalConfig.set({
+			["renderInstrumentation"] = true,
+		})
+		local TestComponent = Component:extend("TestComponent")
+		function TestComponent:render()
+			return nil
+		end
+
+		local instance = Reconciler.reify(Core.createElement(TestComponent))
+
+		local stats = Instrumentation.getCollectedStats()
+		expect(stats.TestComponent).to.be.ok()
+		expect(stats.TestComponent.renderCount).to.equal(1)
+		expect(stats.TestComponent.renderTime).never.to.equal(0)
+
+		Reconciler.teardown(instance)
+		Instrumentation.clearCollectedStats()
+		GlobalConfig.reset()
+	end)
+	it("should count and time shouldUpdate when enabled", function()
+		GlobalConfig.set({
+			["shouldUpdateInstrumentation"] = true,
+		})
+		local setValue
+		local willDoUpdate = false
+
+		local TestComponent = Component:extend("TestComponent")
+
+		function TestComponent:init()
+			self.state = {
+				value = 0,
+			}
+		end
+
+		function TestComponent:shouldUpdate()
+			print("Calling shouldUpdate: " .. tostring(willDoUpdate))
+			return willDoUpdate
+		end
+
+		function TestComponent:didMount()
+			setValue = function(value)
+				self:setState({
+					value = value,
+				})
+			end
+		end
+
+		function TestComponent:render() end
+
+		local instance = Reconciler.reify(Core.createElement(TestComponent))
+
+		local stats = Instrumentation.getCollectedStats()
+		-- Not yet tracked, because only update processing is on
+		expect(stats.TestComponent).never.to.be.ok()
+
+		willDoUpdate = true
+		setValue("whatevs")
+		expect(stats.TestComponent).to.be.ok()
+		expect(stats.TestComponent.updateReqCount).to.equal(1)
+		expect(stats.TestComponent.didUpdateCount).to.equal(1)
+
+		willDoUpdate = false
+		setValue("whatevs")
+		expect(stats.TestComponent.updateReqCount).to.equal(2)
+		expect(stats.TestComponent.didUpdateCount).to.equal(1)
+		expect(stats.TestComponent.shouldUpdateTime).never.to.equal(0)
+
+		Reconciler.teardown(instance)
+		Instrumentation.clearCollectedStats()
+		GlobalConfig.reset()
+	end)
+end

--- a/lib/Instrumentation.spec.lua
+++ b/lib/Instrumentation.spec.lua
@@ -9,9 +9,25 @@ return function()
 		GlobalConfig.set({
 			["renderInstrumentation"] = true,
 		})
+		local triggerUpdate
+
 		local TestComponent = Component:extend("TestComponent")
+		function TestComponent:init()
+			self.state = {
+				value = 0
+			}
+		end
+
 		function TestComponent:render()
 			return nil
+		end
+
+		function TestComponent:didMount()
+			triggerUpdate = function()
+				self:setState({
+					value = self.state.value + 1
+				})
+			end
 		end
 
 		local instance = Reconciler.reify(Core.createElement(TestComponent))
@@ -20,6 +36,9 @@ return function()
 		expect(stats.TestComponent).to.be.ok()
 		expect(stats.TestComponent.renderCount).to.equal(1)
 		expect(stats.TestComponent.renderTime).never.to.equal(0)
+
+		triggerUpdate()
+		expect(stats.TestComponent.renderCount).to.equal(2)
 
 		Reconciler.teardown(instance)
 		Instrumentation.clearCollectedStats()
@@ -41,7 +60,6 @@ return function()
 		end
 
 		function TestComponent:shouldUpdate()
-			print("Calling shouldUpdate: " .. tostring(willDoUpdate))
 			return willDoUpdate
 		end
 

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -7,6 +7,7 @@ local Core = require(script.Core)
 local Event = require(script.Event)
 local Change = require(script.Change)
 local GlobalConfig = require(script.GlobalConfig)
+local Instrumentation = require(script.Instrumentation)
 local PureComponent = require(script.PureComponent)
 local Reconciler = require(script.Reconciler)
 
@@ -44,6 +45,13 @@ apply(Roact, {
 apply(Roact, {
 	setGlobalConfig = GlobalConfig.set,
 	getGlobalConfigValue = GlobalConfig.getValue,
+})
+
+apply(Roact, {
+	Instrumentation = {
+		getCollectedStats = Instrumentation.getCollectedStats,
+		clearCollectedStats = Instrumentation.clearCollectedStats,
+	}
 })
 
 return Roact

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -40,12 +40,16 @@ apply(Roact, {
 	PureComponent = PureComponent,
 	Event = Event,
 	Change = Change,
-	Instrumentation = Instrumentation,
 })
 
 apply(Roact, {
 	setGlobalConfig = GlobalConfig.set,
 	getGlobalConfigValue = GlobalConfig.getValue,
+})
+
+apply(Roact, {
+	getCollectedStats = Instrumentation.getCollectedStats,
+	clearCollectedStats = Instrumentation.clearCollectedStats,
 })
 
 return Roact

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -7,6 +7,7 @@ local Core = require(script.Core)
 local Event = require(script.Event)
 local Change = require(script.Change)
 local GlobalConfig = require(script.GlobalConfig)
+local Instrumentation = require(script.Instrumentation)
 local PureComponent = require(script.PureComponent)
 local Reconciler = require(script.Reconciler)
 
@@ -39,6 +40,7 @@ apply(Roact, {
 	PureComponent = PureComponent,
 	Event = Event,
 	Change = Change,
+	Instrumentation = Instrumentation,
 })
 
 apply(Roact, {

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -7,7 +7,6 @@ local Core = require(script.Core)
 local Event = require(script.Event)
 local Change = require(script.Change)
 local GlobalConfig = require(script.GlobalConfig)
-local Instrumentation = require(script.Instrumentation)
 local PureComponent = require(script.PureComponent)
 local Reconciler = require(script.Reconciler)
 
@@ -45,11 +44,6 @@ apply(Roact, {
 apply(Roact, {
 	setGlobalConfig = GlobalConfig.set,
 	getGlobalConfigValue = GlobalConfig.getValue,
-})
-
-apply(Roact, {
-	getCollectedStats = Instrumentation.getCollectedStats,
-	clearCollectedStats = Instrumentation.clearCollectedStats,
 })
 
 return Roact

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -48,7 +48,8 @@ apply(Roact, {
 })
 
 apply(Roact, {
-	Instrumentation = {
+	-- APIs that may change in the future
+	UNSTABLE = {
 		getCollectedStats = Instrumentation.getCollectedStats,
 		clearCollectedStats = Instrumentation.clearCollectedStats,
 	}

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -20,6 +20,7 @@ return function()
 			Ref = true,
 			None = true,
 			Element = true,
+			UNSTABLE = true,
 		}
 
 		expect(Roact).to.be.ok()


### PR DESCRIPTION
Retrying my approach to tracking performance. This will gather stats about `render` calls and `shouldUpdate` calls, and should be able to provide info that would help indicate when to make a `Component` a `PureComponent` or vice versa, when to write a custom `shouldUpdate`, or when to try to cut down on the complexity of `render` methods.

I didn't find a particularly clean way to inject the instrumentation into the `Component` code without muddling it a bit, so I'd love suggestions for integrating it more gracefully (I left TODOs to this effect).