### PR TITLE
Introduce much more detailed setState error messages

### DIFF
--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -108,22 +108,7 @@ function Reconciler.teardown(instanceHandle)
 			Reconciler.teardown(instanceHandle._reified)
 		end
 	elseif isStatefulElement(element) then
-		-- Stop the component from setting state in willUnmount or anywhere thereafter.
-		instanceHandle._instance._canSetState = false
-
-		-- Tell the component we're about to tear everything down.
-		-- This gives it some notice!
-		if instanceHandle._instance.willUnmount then
-			instanceHandle._instance:willUnmount()
-		end
-
-		-- Stateful components can return nil from render()
-		if instanceHandle._reified then
-			Reconciler.teardown(instanceHandle._reified)
-		end
-
-		-- Cut our circular reference between the instance and its handle
-		instanceHandle._instance = nil
+		instanceHandle._instance:_teardown()
 	elseif isPortal(element) then
 		for _, child in pairs(instanceHandle._reifiedChildren) do
 			Reconciler.teardown(child)

--- a/lib/invalidSetStateMessages.lua
+++ b/lib/invalidSetStateMessages.lua
@@ -28,7 +28,13 @@ Check the definition of shouldUpdate in the component %q.]]
 
 invalidSetStateMessages["init"] = [[
 setState cannot be used in the init method.
-Consider using the didMount method instead.
+During init, the component hasn't initialized yet, and isn't ready to render.
+
+Instead, set the `state` value directly:
+
+	self.state = {
+		value = "foo"
+	}
 
 Check the definition of init in the component %q.]]
 
@@ -43,10 +49,10 @@ setState cannot be called while a component is being reified or reconciled.
 This is the step where Roact constructs Roblox instances, and starting another
 render here would introduce bugs.
 
-Check the component %q to see if:
-	* setState could be called by a child Ref
-	* setState could be called by a child Changed event
-	* setState could be called by a child's render method]]
+Check the component %q to see if setState is being called by:
+* a child Ref
+* a child Changed event
+* a child's render method]]
 
 invalidSetStateMessages["default"] = [[
 setState can not be used in the current situation, but Roact couldn't find a

--- a/lib/invalidSetStateMessages.lua
+++ b/lib/invalidSetStateMessages.lua
@@ -1,0 +1,59 @@
+--[[
+	These messages are used by Component to help users diagnose when they're
+	calling setState in inappropriate places.
+
+	The indentation may seem odd, but it's necessary to avoid introducing extra
+	whitespace into the error messages themselves.
+]]
+
+local invalidSetStateMessages = {}
+
+invalidSetStateMessages["willUpdate"] = [[
+setState cannot be used in the willUpdate lifecycle method.
+Consider using the didUpdate method instead, or using getDerivedStateFromProps.
+
+Check the definition of willUpdate in the component %q.]]
+
+invalidSetStateMessages["willUnmount"] = [[
+setState cannot be used in the willUnmount lifecycle method.
+A component that is being unmounted cannot be updated!
+
+Check the definition of willUnmount in the component %q.]]
+
+invalidSetStateMessages["shouldUpdate"] = [[
+setState cannot be used in the shouldUpdate lifecycle method.
+shouldUpdate must be a pure function that only depends on props and state.
+
+Check the definition of shouldUpdate in the component %q.]]
+
+invalidSetStateMessages["init"] = [[
+setState cannot be used in the init method.
+Consider using the didMount method instead.
+
+Check the definition of init in the component %q.]]
+
+invalidSetStateMessages["render"] = [[
+setState cannot be used in the render method.
+render must be a pure function that only depends on props and state.
+
+Check the definition of render in the component %q.]]
+
+invalidSetStateMessages["reconcile"] = [[
+setState cannot be called while a component is being reified or reconciled.
+This is the step where Roact constructs Roblox instances, and starting another
+render here would introduce bugs.
+
+Check the component %q to see if:
+	* setState could be called by a child Ref
+	* setState could be called by a child Changed event
+	* setState could be called by a child's render method]]
+
+invalidSetStateMessages["default"] = [[
+setState can not be used in the current situation, but Roact couldn't find a
+message to display.
+
+This is a bug in Roact.
+It was triggered by the component %q.
+]]
+
+return invalidSetStateMessages


### PR DESCRIPTION
Fixes #66.

This PR replaces the single "you can't use setState here" message with a bunch of new messages, each tailored to the exact case.

They give much more useful information, and where possible, where to put your `setState` call instead.

It also catches an extra case where the render and reconciliation steps _were not_ being guarded, specifically during reify.