### PR TITLE
createRef API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the static lifecycle method `getDerivedStateFromProps` ([#57](https://github.com/Roblox/roact/pull/57))
 * Allow canceling render by returning nil from setState callback ([#64](https://github.com/Roblox/roact/pull/64))
 * Added `defaultProps` value on stateful components to define values for props that aren't specified ([#79](https://github.com/Roblox/roact/pull/79))
+* Added `createRef` ([#70](https://github.com/Roblox/roact/issues/70), [#92](https://github.com/Roblox/roact/pull/92))
 
 ## 1.0.0 Prerelease 2 (March 22, 2018)
 * Removed `is*Element` methods, this is unlikely to affect anyone ([#50](https://github.com/Roblox/roact/pull/50))

--- a/docs/advanced/refs.md
+++ b/docs/advanced/refs.md
@@ -8,59 +8,7 @@
 To create a ref, pass a function prop with the key `Roact.Ref` when creating a primitive element.
 
 For example, suppose we wanted to create a search bar that captured cursor focus when any part of it was clicked. We might use a component like this:
-```lua
---[[
-	A search bar with an icon and a text box that captures focus for its TextBox
-	when its icon is clicked
- ]]
-local SearchBar = Roact.Component:extend("SearchBar")
 
-function SearchBar:init()
-	-- Roact.createRef creates an object reference.
-	-- This has a single property, `current`, that can be used to access the
-	-- current Roblox instance.
-	self.textBoxRef = Roact.createRef()
-end
-
-function SearchBar:captureFocus()
-	local textBox = self.textBoxRef.current
-
-	-- If we have a current instance, capture focus on it.
-	-- current will be nil if the component hasn't been mounted yet, or it's
-	-- being unmounted.
-	if textBox then
-		textBox:CaptureFocus()
-	end
-end
-
-function SearchBar:render()
-	-- Render our icon and text box side by side in a Frame
-	return Roact.createElement("Frame", {
-		Size = UDim2.new(0, 200, 0, 20),
-	}, {
-		SearchIcon = Roact.createElement("ImageButton", {
-			Size = UDim2.new(0, 20, 0, 20),
-			-- Handle click events on the icon
-			[Roact.Event.MouseButton1Click] = function()
-				self:captureFocus()
-			end,
-		}),
-
-		SearchTextBox = Roact.createElement("TextBox", {
-			Size = UDim2.new(0, 180, 0, 20),
-			Position = UDim2.new(0, 20, 0, 0),
-			-- We use Roact.Ref to get a reference to the underlying object
-			-- Roact will set textBoxRef.current to the underlying object as
-			-- part of the rendering process.
-			[Roact.Ref] = self.textBoxRef,
-		}),
-	})
-end
-```
-When a user clicks on the outer `ImageButton`, the `captureFocus` method will be called and the `TextBox` instance will get focus as if it had been clicked on directly.
-
-## Functional Refs
-Roact allows you to use functions as refs. The function will be called with the Roblox object that Roact creates. For example, this is the SearchBar component from above, modified to use functional refs instead of object refs:
 ```lua
 --[[
 	A search bar with an icon and a text box that captures focus for its TextBox
@@ -103,7 +51,6 @@ end
 When a user clicks on the outer `ImageButton`, the `captureTextboxFocus` callback will be triggered and the `TextBox` instance will get focus as if it had been clicked on directly.
 
 ## Refs During Teardown
-
 !!! warning
 	When a component instance is destroyed or the ref property changes, `nil` will be passed to the old ref function!
 

--- a/docs/advanced/refs.md
+++ b/docs/advanced/refs.md
@@ -8,7 +8,59 @@
 To create a ref, pass a function prop with the key `Roact.Ref` when creating a primitive element.
 
 For example, suppose we wanted to create a search bar that captured cursor focus when any part of it was clicked. We might use a component like this:
+```lua
+--[[
+	A search bar with an icon and a text box that captures focus for its TextBox
+	when its icon is clicked
+ ]]
+local SearchBar = Roact.Component:extend("SearchBar")
 
+function SearchBar:init()
+	-- Roact.createRef creates an object reference.
+	-- This has a single property, `current`, that can be used to access the
+	-- current Roblox instance.
+	self.textBoxRef = Roact.createRef()
+end
+
+function SearchBar:captureFocus()
+	local textBox = self.textBoxRef.current
+
+	-- If we have a current instance, capture focus on it.
+	-- current will be nil if the component hasn't been mounted yet, or it's
+	-- being unmounted.
+	if textBox then
+		textBox:CaptureFocus()
+	end
+end
+
+function SearchBar:render()
+	-- Render our icon and text box side by side in a Frame
+	return Roact.createElement("Frame", {
+		Size = UDim2.new(0, 200, 0, 20),
+	}, {
+		SearchIcon = Roact.createElement("ImageButton", {
+			Size = UDim2.new(0, 20, 0, 20),
+			-- Handle click events on the icon
+			[Roact.Event.MouseButton1Click] = function()
+				self:captureFocus()
+			end,
+		}),
+
+		SearchTextBox = Roact.createElement("TextBox", {
+			Size = UDim2.new(0, 180, 0, 20),
+			Position = UDim2.new(0, 20, 0, 0),
+			-- We use Roact.Ref to get a reference to the underlying object
+			-- Roact will set textBoxRef.current to the underlying object as
+			-- part of the rendering process.
+			[Roact.Ref] = self.textBoxRef,
+		}),
+	})
+end
+```
+When a user clicks on the outer `ImageButton`, the `captureFocus` method will be called and the `TextBox` instance will get focus as if it had been clicked on directly.
+
+## Functional Refs
+Roact allows you to use functions as refs. The function will be called with the Roblox object that Roact creates. For example, this is the SearchBar component from above, modified to use functional refs instead of object refs:
 ```lua
 --[[
 	A search bar with an icon and a text box that captures focus for its TextBox
@@ -51,6 +103,7 @@ end
 When a user clicks on the outer `ImageButton`, the `captureTextboxFocus` callback will be triggered and the `TextBox` instance will get focus as if it had been clicked on directly.
 
 ## Refs During Teardown
+
 !!! warning
 	When a component instance is destroyed or the ref property changes, `nil` will be passed to the old ref function!
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -61,6 +61,13 @@ If `children` contains more than one child, `oneChild` function will throw an er
 
 If `children` is `nil` or contains no children, `oneChild` will return `nil`.
 
+### Roact.createRef
+```
+Roact.createRef() -> Ref
+```
+
+Creates a new reference object that can be used with [Roact.Ref](#roactref).
+
 ## Constants
 
 ### Roact.Children
@@ -72,6 +79,10 @@ If you're writing a new functional or stateful element that needs to be used lik
 Use `Roact.Ref` as a key into the props of a primitive element to receive a handle to the underlying Roblox Instance.
 
 ```lua
+Roact.createElement("Frame", {
+	[Roact.Ref] = objectReference,
+})
+
 Roact.createElement("Frame", {
 	[Roact.Ref] = function(rbx)
 		print("Roblox Instance", rbx)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -61,6 +61,13 @@ If `children` contains more than one child, `oneChild` function will throw an er
 
 If `children` is `nil` or contains no children, `oneChild` will return `nil`.
 
+### Roact.createRef
+```
+Roact.createRef() -> Ref
+```
+
+Creates a new reference object that can be used with [Roact.Ref](#roactref).
+
 ## Constants
 
 ### Roact.Children
@@ -71,12 +78,32 @@ If you're writing a new functional or stateful element that needs to be used lik
 ### Roact.Ref
 Use `Roact.Ref` as a key into the props of a primitive element to receive a handle to the underlying Roblox Instance.
 
+`Ref` may either be a function:
 ```lua
 Roact.createElement("Frame", {
 	[Roact.Ref] = function(rbx)
 		print("Roblox Instance", rbx)
 	end,
 })
+```
+
+Or a reference object created with [createRef](#roactcreateref):
+```lua
+local ExampleComponent = Roact.Component:extend("ExampleComponent")
+
+function ExampleComponent:init()
+	self.ref = Roact.createRef()
+end
+
+function ExampleComponent:render()
+	return Roact.createElement("Frame", {
+		[Roact.Ref] = ref,
+	})
+end
+
+function ExampleComponent:didMount()
+	print("Roblox Instance", self.ref.current)
+end
 ```
 
 !!! warning

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -61,13 +61,6 @@ If `children` contains more than one child, `oneChild` function will throw an er
 
 If `children` is `nil` or contains no children, `oneChild` will return `nil`.
 
-### Roact.createRef
-```
-Roact.createRef() -> Ref
-```
-
-Creates a new reference object that can be used with [Roact.Ref](#roactref).
-
 ## Constants
 
 ### Roact.Children
@@ -79,10 +72,6 @@ If you're writing a new functional or stateful element that needs to be used lik
 Use `Roact.Ref` as a key into the props of a primitive element to receive a handle to the underlying Roblox Instance.
 
 ```lua
-Roact.createElement("Frame", {
-	[Roact.Ref] = objectReference,
-})
-
 Roact.createElement("Frame", {
 	[Roact.Ref] = function(rbx)
 		print("Roblox Instance", rbx)

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -81,6 +81,7 @@ Use `Roact.Ref` as a key into the props of a primitive element to receive a hand
 `Ref` may either be a function:
 ```lua
 Roact.createElement("Frame", {
+	-- The function given will be called whenever the rendered instance changes.
 	[Roact.Ref] = function(rbx)
 		print("Roblox Instance", rbx)
 	end,
@@ -92,16 +93,19 @@ Or a reference object created with [createRef](#roactcreateref):
 local ExampleComponent = Roact.Component:extend("ExampleComponent")
 
 function ExampleComponent:init()
+	-- Create a reference object.
 	self.ref = Roact.createRef()
 end
 
 function ExampleComponent:render()
 	return Roact.createElement("Frame", {
+		-- Use the reference object to point to this rendered instance.
 		[Roact.Ref] = ref,
 	})
 end
 
 function ExampleComponent:didMount()
+	-- Access the current value of a reference object using its current property.
 	print("Roblox Instance", self.ref.current)
 end
 ```

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -346,7 +346,7 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 
 		-- Apply the new ref if there was a ref change.
 		if refChanged and newRef then
-			newRef(instanceHandle._rbx)
+			applyRef(newRef, instanceHandle._rbx)
 		end
 
 		return instanceHandle

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -49,7 +49,9 @@ end
 	Correctly handles both function-style and object-style refs.
 ]]
 local function applyRef(ref, newRbx)
-	if not ref then return end
+	if ref == nil then
+		return
+	end
 
 	if type(ref) == "table" then
 		ref.current = newRbx

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -329,8 +329,8 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 	if isPrimitiveElement(newElement) then
 		-- Roblox Instance change
 
-		local oldRef = oldElement[Core.Ref]
-		local newRef = newElement[Core.Ref]
+		local oldRef = oldElement.props[Core.Ref]
+		local newRef = newElement.props[Core.Ref]
 		local refChanged = (oldRef ~= newRef)
 
 		-- Cancel the old ref before we make changes. Apply the new one after.

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -49,6 +49,8 @@ end
 	Correctly handles both function-style and object-style refs.
 ]]
 local function applyRef(ref, newRbx)
+	if not ref then return end
+
 	if type(ref) == "table" then
 		ref.current = newRbx
 	else
@@ -105,11 +107,7 @@ function Reconciler.unmount(instanceHandle)
 
 		-- Kill refs before we make changes, since any mutations past this point
 		-- aren't relevant to components.
-		local ref = element.props[Core.Ref]
-
-		if ref then
-			applyRef(ref, nil)
-		end
+		applyRef(element.props[Core.Ref], nil)
 
 		for _, child in pairs(instanceHandle._children) do
 			Reconciler.unmount(child)
@@ -187,10 +185,7 @@ function Reconciler._mountInternal(element, parent, key, context)
 		rbx.Parent = parent
 
 		-- Attach ref values, since the instance is initialized now.
-		local ref = element.props[Core.Ref]
-		if ref then
-			applyRef(ref, rbx)
-		end
+		applyRef(element.props[Core.Ref], rbx)
 
 		return {
 			[isInstanceHandle] = true,

--- a/lib/Reconciler.spec.lua
+++ b/lib/Reconciler.spec.lua
@@ -36,4 +36,51 @@ return function()
 		Reconciler.unmount(handle)
 		expect(currentRbx).to.never.be.ok()
 	end)
+
+	it("should handle changing function references", function()
+		local aValue, bValue
+
+		local function aRef(rbx)
+			aValue = rbx
+		end
+
+		local function bRef(rbx)
+			bValue = rbx
+		end
+
+		local element = Core.createElement("StringValue", {
+			[Core.Ref] = aRef,
+		})
+
+		local handle = Reconciler.mount(element, game, "Test123")
+		expect(aValue).to.be.ok()
+		expect(bValue).to.never.be.ok()
+		handle = Reconciler.reconcile(handle, Core.createElement("StringValue", {
+			[Core.Ref] = bRef,
+		}))
+		expect(aValue).to.never.be.ok()
+		expect(bValue).to.be.ok()
+		Reconciler.unmount(handle)
+		expect(bValue).to.never.be.ok()
+	end)
+
+	it("should handle changing object references", function()
+		local aRef = createRef()
+		local bRef = createRef()
+
+		local element = Core.createElement("StringValue", {
+			[Core.Ref] = aRef,
+		})
+
+		local handle = Reconciler.mount(element, game, "Test123")
+		expect(aRef.current).to.be.ok()
+		expect(bRef.current).to.never.be.ok()
+		handle = Reconciler.reconcile(handle, Core.createElement("StringValue", {
+			[Core.Ref] = bRef,
+		}))
+		expect(aRef.current).to.never.be.ok()
+		expect(bRef.current).to.be.ok()
+		Reconciler.unmount(handle)
+		expect(bRef.current).to.never.be.ok()
+	end)
 end

--- a/lib/Reconciler.spec.lua
+++ b/lib/Reconciler.spec.lua
@@ -1,8 +1,39 @@
 return function()
+	local Core = require(script.Parent.Core)
 	local Reconciler = require(script.Parent.Reconciler)
+	local createRef = require(script.Parent.createRef)
 
 	it("should mount booleans as nil", function()
 		local booleanReified = Reconciler.mount(false)
 		expect(booleanReified).to.never.be.ok()
+	end)
+
+	it("should handle object references properly", function()
+		local objectRef = createRef()
+		local element = Core.createElement("StringValue", {
+			[Core.Ref] = objectRef,
+		})
+
+		local handle = Reconciler.mount(element)
+		expect(objectRef.current).to.be.ok()
+		Reconciler.unmount(handle)
+		expect(objectRef.current).to.never.be.ok()
+	end)
+
+	it("should handle function references properly", function()
+		local currentRbx
+
+		local function ref(rbx)
+			currentRbx = rbx
+		end
+
+		local element = Core.createElement("StringValue", {
+			[Core.Ref] = ref,
+		})
+
+		local handle = Reconciler.mount(element)
+		expect(currentRbx).to.be.ok()
+		Reconciler.unmount(handle)
+		expect(currentRbx).to.never.be.ok()
 	end)
 end

--- a/lib/createRef.lua
+++ b/lib/createRef.lua
@@ -1,0 +1,14 @@
+--[[
+	Provides an API for acquiring a reference to a reified object. This
+	API is designed to mimic React 16.3's createRef API.
+
+	See:
+	* https://reactjs.org/docs/refs-and-the-dom.html
+	* https://reactjs.org/blog/2018/03/29/react-v-16-3.html#createref-api
+]]
+
+return function()
+	return {
+		current = nil,
+	}
+end

--- a/lib/createRef.lua
+++ b/lib/createRef.lua
@@ -7,8 +7,14 @@
 	* https://reactjs.org/blog/2018/03/29/react-v-16-3.html#createref-api
 ]]
 
+local refMetatable = {
+	__tostring = function(self)
+		return ("RoactReference(%q)"):format(tostring(self.current))
+	end,
+}
+
 return function()
-	return {
+	return setmetatable({
 		current = nil,
-	}
+	}, refMetatable)
 end

--- a/lib/createRef.lua
+++ b/lib/createRef.lua
@@ -9,7 +9,7 @@
 
 local refMetatable = {
 	__tostring = function(self)
-		return ("RoactReference(%q)"):format(tostring(self.current))
+		return ("RoactReference(%s)"):format(tostring(self.current))
 	end,
 }
 

--- a/lib/createRef.spec.lua
+++ b/lib/createRef.spec.lua
@@ -1,0 +1,7 @@
+return function()
+	local createRef = require(script.Parent.createRef)
+
+	it("should create refs", function()
+		expect(createRef()).to.be.ok()
+	end)
+end

--- a/lib/createRef.spec.lua
+++ b/lib/createRef.spec.lua
@@ -8,5 +8,8 @@ return function()
 	it("should support tostring on refs", function()
 		local ref = createRef()
 		expect(tostring(ref)).to.equal("RoactReference(\"nil\")")
+
+		ref.current = "foo"
+		expect(tostring(ref)).to.equal("RoactReference(\"foo\")")
 	end)
 end

--- a/lib/createRef.spec.lua
+++ b/lib/createRef.spec.lua
@@ -7,9 +7,9 @@ return function()
 
 	it("should support tostring on refs", function()
 		local ref = createRef()
-		expect(tostring(ref)).to.equal("RoactReference(\"nil\")")
+		expect(tostring(ref)).to.equal("RoactReference(nil)")
 
 		ref.current = "foo"
-		expect(tostring(ref)).to.equal("RoactReference(\"foo\")")
+		expect(tostring(ref)).to.equal("RoactReference(foo)")
 	end)
 end

--- a/lib/createRef.spec.lua
+++ b/lib/createRef.spec.lua
@@ -4,4 +4,9 @@ return function()
 	it("should create refs", function()
 		expect(createRef()).to.be.ok()
 	end)
+
+	it("should support tostring on refs", function()
+		local ref = createRef()
+		expect(tostring(ref)).to.equal("RoactReference(\"nil\")")
+	end)
 end

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -4,6 +4,7 @@
 
 local Component = require(script.Component)
 local Core = require(script.Core)
+local createRef = require(script.createRef)
 local Event = require(script.Event)
 local Change = require(script.Change)
 local GlobalConfig = require(script.GlobalConfig)
@@ -39,6 +40,7 @@ apply(Roact, ReconcilerCompat)
 
 apply(Roact, {
 	Component = Component,
+	createRef = createRef,
 	PureComponent = PureComponent,
 	Event = Event,
 	Change = Change,

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -4,6 +4,7 @@ return function()
 	it("should load with all public APIs", function()
 		local publicApi = {
 			createElement = "function",
+			createRef = "function",
 			mount = "function",
 			unmount = "function",
 			reconcile = "function",


### PR DESCRIPTION
Closes #70.

Adds a `createRef` function to the global Roact namespace. `createRef` returns an object reference with a `current` property that can be used like existing functional refs. Example usage:

```lua
local SomeTextbox = Roact.Component:extend("SomeTextbox")

function SomeTextbox:init()
    self.textboxRef = Roact.createRef()
end

function SomeTextbox:render()
    return Roact.createElement("TextBox", {
        -- ...
        [Roact.Ref] = self.textboxRef
    })
end

function SomeTextbox:didMount()
    self.textboxRef.current:CaptureFocus()
end
```