### PR TITLE
Add stackTrace getter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added the static lifecycle method `getDerivedStateFromProps` ([#57](https://github.com/Roblox/roact/pull/57))
 * Allow canceling render by returning nil from setState callback ([#64](https://github.com/Roblox/roact/pull/64))
 * Added `defaultProps` value on stateful components to define values for props that aren't specified ([#79](https://github.com/Roblox/roact/pull/79))
+* Added `getElementTraceback` ([#81](https://github.com/Roblox/roact/issues/81), [#93](https://github.com/Roblox/roact/pull/93))
 
 ## 1.0.0 Prerelease 2 (March 22, 2018)
 * Removed `is*Element` methods, this is unlikely to affect anyone ([#50](https://github.com/Roblox/roact/pull/50))

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -241,12 +241,12 @@ Right now, components are re-rendered any time a parent component updates, or wh
 
 `PureComponent` implements `shouldUpdate` to only trigger a re-render any time the props are different based on shallow equality. In a future Roact update, *all* components may implement this check by default.
 
-### stackTrace
+### rootElementTraceback
 ```
-stackTrace() -> string | nil
+rootElementTraceback() -> string | nil
 ```
 
-`stackTrace` gets the stack trace that the component was created in. This allows you to report error messages accurately.
+`rootElementTraceback` gets the stack trace that the component was created in. This allows you to report error messages accurately.
 
 ## Lifecycle Methods
 In addition to the base Component API, Roact exposes additional lifecycle methods that stateful components can hook into to be notified of various steps in the rendering process.

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -241,6 +241,13 @@ Right now, components are re-rendered any time a parent component updates, or wh
 
 `PureComponent` implements `shouldUpdate` to only trigger a re-render any time the props are different based on shallow equality. In a future Roact update, *all* components may implement this check by default.
 
+### stackTrace
+```
+stackTrace() -> string | nil
+```
+
+`stackTrace` gets the stack trace that the component was created in. This allows you to report error messages accurately.
+
 ## Lifecycle Methods
 In addition to the base Component API, Roact exposes additional lifecycle methods that stateful components can hook into to be notified of various steps in the rendering process.
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -241,12 +241,12 @@ Right now, components are re-rendered any time a parent component updates, or wh
 
 `PureComponent` implements `shouldUpdate` to only trigger a re-render any time the props are different based on shallow equality. In a future Roact update, *all* components may implement this check by default.
 
-### rootElementTraceback
+### getElementTraceback
 ```
-rootElementTraceback() -> string | nil
+getElementTraceback() -> string | nil
 ```
 
-`rootElementTraceback` gets the stack trace that the component was created in. This allows you to report error messages accurately.
+`getElementTraceback` gets the stack trace that the component was created in. This allows you to report error messages accurately.
 
 ## Lifecycle Methods
 In addition to the base Component API, Roact exposes additional lifecycle methods that stateful components can hook into to be notified of various steps in the rendering process.

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -243,7 +243,7 @@ end
 	Returns the current stack trace for this component, or nil if the
 	elementTracing configuration flag is set to false.
 ]]
-function Component:stackTrace()
+function Component:rootElementTraceback()
 	return self._handle._element.source
 end
 

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -243,7 +243,7 @@ end
 	Returns the current stack trace for this component, or nil if the
 	elementTracing configuration flag is set to false.
 ]]
-function Component:rootElementTraceback()
+function Component:getElementTraceback()
 	return self._handle._element.source
 end
 

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -240,6 +240,14 @@ function Component:setState(partialState)
 end
 
 --[[
+	Returns the current stack trace for this component, or nil if the
+	elementTracing configuration flag is set to false.
+]]
+function Component:stackTrace()
+	return self._handle._element.source
+end
+
+--[[
 	Notifies the component that new props and state are available. This function
 	is invoked by the reconciler.
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -525,7 +525,7 @@ return function()
 		end)
 	end)
 
-	describe("rootElementTraceback", function()
+	describe("getElementTraceback", function()
 		it("should return stack traces", function()
 			local stackTraceCallback = nil
 
@@ -537,7 +537,7 @@ return function()
 
 			function TestComponent:init()
 				stackTraceCallback = function()
-					return self:rootElementTraceback()
+					return self:getElementTraceback()
 				end
 			end
 
@@ -558,7 +558,7 @@ return function()
 
 			function TestComponent:init()
 				stackTraceCallback = function()
-					return self:rootElementTraceback()
+					return self:getElementTraceback()
 				end
 			end
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -525,7 +525,7 @@ return function()
 		end)
 	end)
 
-	describe("stackTrace", function()
+	describe("rootElementTraceback", function()
 		it("should return stack traces", function()
 			local stackTraceCallback = nil
 
@@ -537,7 +537,7 @@ return function()
 
 			function TestComponent:init()
 				stackTraceCallback = function()
-					return self:stackTrace()
+					return self:rootElementTraceback()
 				end
 			end
 
@@ -558,7 +558,7 @@ return function()
 
 			function TestComponent:init()
 				stackTraceCallback = function()
-					return self:stackTrace()
+					return self:rootElementTraceback()
 				end
 			end
 

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -2,6 +2,7 @@ return function()
 	local Core = require(script.Parent.Core)
 	local Reconciler = require(script.Parent.Reconciler)
 	local Component = require(script.Parent.Component)
+	local GlobalConfig = require(script.Parent.GlobalConfig)
 
 	it("should be extendable", function()
 		local MyComponent = Component:extend("The Senate")
@@ -521,6 +522,53 @@ return function()
 			expect(renderCount).to.equal(1)
 
 			Reconciler.unmount(instance)
+		end)
+	end)
+
+	describe("stackTrace", function()
+		it("should return stack traces", function()
+			local stackTraceCallback = nil
+
+			GlobalConfig.set({
+				elementTracing = true
+			})
+
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:init()
+				stackTraceCallback = function()
+					return self:stackTrace()
+				end
+			end
+
+			function TestComponent:render()
+				return Core.createElement("StringValue")
+			end
+
+			local handle = Reconciler.mount(Core.createElement(TestComponent))
+			expect(stackTraceCallback()).to.be.ok()
+			Reconciler.unmount(handle)
+			GlobalConfig.reset()
+		end)
+
+		it("should return nil when elementTracing is off", function()
+			local stackTraceCallback = nil
+
+			local TestComponent = Component:extend("TestComponent")
+
+			function TestComponent:init()
+				stackTraceCallback = function()
+					return self:stackTrace()
+				end
+			end
+
+			function TestComponent:render()
+				return Core.createElement("StringValue")
+			end
+
+			local handle = Reconciler.mount(Core.createElement(TestComponent))
+			expect(stackTraceCallback()).to.never.be.ok()
+			Reconciler.unmount(handle)
 		end)
 	end)
 end


### PR DESCRIPTION
Closes #81. Adds a `stackTrace` method to `Component` that returns the current stack trace for the instance. This will return `nil` when `elementTracing` is `false`.