### PR TITLE
Change refs in one pass, making switching refs atomic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `defaultProps` value on stateful components to define values for props that aren't specified ([#79](https://github.com/Roblox/roact/pull/79))
 * Added `getElementTraceback` ([#81](https://github.com/Roblox/roact/issues/81), [#93](https://github.com/Roblox/roact/pull/93))
 * Added `createRef` ([#70](https://github.com/Roblox/roact/issues/70), [#92](https://github.com/Roblox/roact/pull/92))
+* Ref switching now occurs in one pass, which should fix edge cases where the result of a ref is `nil`, especially in property changed events ([#98](https://github.com/Roblox/roact/pull/98))
 
 ## 1.0.0 Prerelease 2 (March 22, 2018)
 * Removed `is*Element` methods, this is unlikely to affect anyone ([#50](https://github.com/Roblox/roact/pull/50))

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -331,11 +331,13 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 
 		local oldRef = oldElement.props[Core.Ref]
 		local newRef = newElement.props[Core.Ref]
-		local refChanged = (oldRef ~= newRef)
 
-		-- Cancel the old ref before we make changes. Apply the new one after.
-		if refChanged and oldRef then
+		-- Change the ref in one pass before applying any changes.
+		-- Roact doesn't provide any guarantees with regards to the sequencing
+		-- between refs and other changes in the commit phase.
+		if newRef ~= oldRef then
 			applyRef(oldRef, nil)
+			applyRef(newRef, instanceHandle._rbx)
 		end
 
 		-- Update properties and children of the Roblox object.
@@ -343,11 +345,6 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 		Reconciler._reconcilePrimitiveChildren(instanceHandle, newElement)
 
 		instanceHandle._element = newElement
-
-		-- Apply the new ref if there was a ref change.
-		if refChanged and newRef then
-			applyRef(newRef, instanceHandle._rbx)
-		end
 
 		return instanceHandle
 	elseif isFunctionalElement(newElement) then


### PR DESCRIPTION
This is a minor change that ideally shouldn't be user-visible.

Before #92, there was a bug in Roact where when refs were updated, nothing would happen. There was a typo in the reconciler code that resulted in the comparison in the reconciler always determining that refs never changed!

After #92, an issue was unveiled by @ZoteTheMighty via some internal Roact code that means that with the typical use of a ref:

```lua
[Roact.Ref] = (rbx)
   self.foo = rbx
end
```

...there is a period of time where `self.foo` will be `nil` when Roact nullifies the old ref, makes changes, and then passes the same object to the new ref, since by function identity it changed. This doesn't affect code that keeps a stable ref function, and is only visible to code that acts on a ref in response to a change event.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [ ] ~Tests added and updated~ I don't think we can test this