### PR TITLE
Do not merge: Async retrofit

### DIFF
--- a/lib/AsyncScheduler.lua
+++ b/lib/AsyncScheduler.lua
@@ -1,0 +1,58 @@
+local RunService = game:GetService("RunService")
+
+local AsyncScheduler = {}
+AsyncScheduler.__index = AsyncScheduler
+
+function AsyncScheduler.new(budget)
+	local self = setmetatable({}, AsyncScheduler)
+
+	self.tasks = {}
+	self.startIndex = 1
+
+	self.connection = RunService.Stepped:Connect(function()
+		self:step(budget)
+	end)
+
+	return self
+end
+
+function AsyncScheduler:schedule(task)
+	self.tasks[#self.tasks + 1] = task
+end
+
+function AsyncScheduler:destruct()
+	self.connection:Disconnect()
+end
+
+function AsyncScheduler:step(budget)
+	if #self.tasks == 0 then
+		return
+	end
+
+	local startTime = tick()
+
+	local i = self.startIndex
+	while true do
+		local task = self.tasks[i]
+		i = i + 1
+
+		if task == nil then
+			self.tasks = {}
+			self.startIndex = 1
+			break
+		end
+
+		task()
+
+		if tick() - startTime >= budget then
+			self.startIndex = i
+			break
+		end
+	end
+end
+
+function AsyncScheduler:flush()
+	self:step(math.huge)
+end
+
+return AsyncScheduler

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -257,17 +257,7 @@ end
 function Component:_update(newProps, newState)
 	self._setStateBlockedReason = "shouldUpdate"
 
-	local doUpdate
-	if GlobalConfig.getValue("componentInstrumentation") then
-		local startTime = tick()
-
-		doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
-
-		local elapsed = tick() - startTime
-		Instrumentation.logShouldUpdate(self._handle, doUpdate, elapsed)
-	else
-		doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
-	end
+	local doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
 
 	self._setStateBlockedReason = nil
 
@@ -336,17 +326,7 @@ function Component:_forceUpdate(newProps, newState)
 
 	self._setStateBlockedReason = "render"
 
-	local newChildElement
-	if GlobalConfig.getValue("componentInstrumentation") then
-		local startTime = tick()
-
-		newChildElement = self:render()
-
-		local elapsed = tick() - startTime
-		Instrumentation.logRenderTime(self._handle, elapsed)
-	else
-		newChildElement = self:render()
-	end
+	local newChildElement = self:render()
 
 	self._setStateBlockedReason = nil
 
@@ -369,7 +349,9 @@ function Component:_forceUpdate(newProps, newState)
 	self._setStateBlockedReason = nil
 
 	if self.didUpdate then
-		self:didUpdate(oldProps, oldState)
+		Reconciler._schedule(function()
+			self:didUpdate(oldProps, oldState)
+		end)
 	end
 end
 
@@ -382,17 +364,7 @@ function Component:_mount(handle)
 
 	self._setStateBlockedReason = "render"
 
-	local virtualTree
-	if GlobalConfig.getValue("componentInstrumentation") then
-		local startTime = tick()
-
-		virtualTree = self:render()
-
-		local elapsed = tick() - startTime
-		Instrumentation.logRenderTime(self._handle, elapsed)
-	else
-		virtualTree = self:render()
-	end
+	local virtualTree = self:render()
 
 	self._setStateBlockedReason = nil
 
@@ -408,7 +380,9 @@ function Component:_mount(handle)
 	end
 
 	if self.didMount then
-		self:didMount()
+		Reconciler._schedule(function()
+			self:didMount()
+		end)
 	end
 end
 

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -236,7 +236,10 @@ function Component:setState(partialState)
 	end
 
 	local newState = merge(self.state, partialState)
-	self:_update(nil, newState)
+
+	Reconciler._schedule(function()
+		self:_update(nil, newState)
+	end)
 end
 
 --[[

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -32,6 +32,9 @@ local getDefaultPropertyValue = require(script.Parent.getDefaultPropertyValue)
 local SingleEventManager = require(script.Parent.SingleEventManager)
 local Symbol = require(script.Parent.Symbol)
 
+local AsyncScheduler = require(script.Parent.AsyncScheduler)
+local SyncScheduler = require(script.Parent.SyncScheduler)
+
 local isInstanceHandle = Symbol.named("isInstanceHandle")
 
 local DEFAULT_SOURCE = "\n\t<Use Roact.setGlobalConfig with the 'elementTracing' key to enable detailed tracebacks>\n"
@@ -60,8 +63,14 @@ local function applyRef(ref, newRbx)
 	end
 end
 
+local scheduler = AsyncScheduler.new(12 / 1000)
+local function schedule(task)
+	scheduler:schedule(task)
+end
+
 local Reconciler = {}
 
+Reconciler._schedule = schedule
 Reconciler._singleEventManager = SingleEventManager.new()
 
 --[[
@@ -104,35 +113,37 @@ end
 function Reconciler.unmount(instanceHandle)
 	local element = instanceHandle._element
 
-	if isPrimitiveElement(element) then
-		-- We're destroying a Roblox Instance-based object
+	schedule(function()
+		if isPrimitiveElement(element) then
+			-- We're destroying a Roblox Instance-based object
 
-		-- Kill refs before we make changes, since any mutations past this point
-		-- aren't relevant to components.
-		applyRef(element.props[Core.Ref], nil)
+			-- Kill refs before we make changes, since any mutations past this point
+			-- aren't relevant to components.
+			applyRef(element.props[Core.Ref], nil)
 
-		for _, child in pairs(instanceHandle._children) do
-			Reconciler.unmount(child)
+			for _, child in pairs(instanceHandle._children) do
+				Reconciler.unmount(child)
+			end
+
+			-- Necessary to make sure SingleEventManager doesn't leak references
+			Reconciler._singleEventManager:disconnectAll(instanceHandle._rbx)
+
+			instanceHandle._rbx:Destroy()
+		elseif isFunctionalElement(element) then
+			-- Functional components can return nil
+			if instanceHandle._child then
+				Reconciler.unmount(instanceHandle._child)
+			end
+		elseif isStatefulElement(element) then
+			instanceHandle._instance:_unmount()
+		elseif isPortal(element) then
+			for _, child in pairs(instanceHandle._children) do
+				Reconciler.unmount(child)
+			end
+		else
+			error(("Cannot unmount invalid Roact instance %q"):format(tostring(element)))
 		end
-
-		-- Necessary to make sure SingleEventManager doesn't leak references
-		Reconciler._singleEventManager:disconnectAll(instanceHandle._rbx)
-
-		instanceHandle._rbx:Destroy()
-	elseif isFunctionalElement(element) then
-		-- Functional components can return nil
-		if instanceHandle._child then
-			Reconciler.unmount(instanceHandle._child)
-		end
-	elseif isStatefulElement(element) then
-		instanceHandle._instance:_unmount()
-	elseif isPortal(element) then
-		for _, child in pairs(instanceHandle._children) do
-			Reconciler.unmount(child)
-		end
-	else
-		error(("Cannot unmount invalid Roact instance %q"):format(tostring(element)))
-	end
+	end)
 end
 
 --[[
@@ -159,7 +170,16 @@ function Reconciler._mountInternal(element, parent, key, context)
 	if isPrimitiveElement(element) then
 		-- Primitive elements are backed directly by Roblox Instances.
 
+		local handle = {
+			[isInstanceHandle] = true,
+			_key = key,
+			_parent = parent,
+			_element = element,
+			_context = context,
+		}
+
 		local rbx = Instance.new(element.component)
+		handle._rbx = rbx
 
 		-- Update Roblox properties
 		for key, value in pairs(element.props) do
@@ -168,6 +188,7 @@ function Reconciler._mountInternal(element, parent, key, context)
 
 		-- Create children!
 		local children = {}
+		handle._children = children
 
 		if element.props[Core.Children] then
 			for key, childElement in pairs(element.props[Core.Children]) do
@@ -189,15 +210,7 @@ function Reconciler._mountInternal(element, parent, key, context)
 		-- Attach ref values, since the instance is initialized now.
 		applyRef(element.props[Core.Ref], rbx)
 
-		return {
-			[isInstanceHandle] = true,
-			_key = key,
-			_parent = parent,
-			_element = element,
-			_context = context,
-			_children = children,
-			_rbx = rbx,
-		}
+		return handle
 	elseif isFunctionalElement(element) then
 		-- Functional elements contain 0 or 1 children.
 
@@ -231,7 +244,10 @@ function Reconciler._mountInternal(element, parent, key, context)
 		local instance = element.component._new(element.props, context)
 
 		instanceHandle._instance = instance
-		instance:_mount(instanceHandle)
+
+		schedule(function()
+			instance:_mount(instanceHandle)
+		end)
 
 		return instanceHandle
 	elseif isPortal(element) then
@@ -339,7 +355,6 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 			applyRef(oldRef, nil)
 			applyRef(newRef, instanceHandle._rbx)
 		end
-
 		-- Update properties and children of the Roblox object.
 		Reconciler._reconcilePrimitiveProps(oldElement, newElement, instanceHandle._rbx)
 		Reconciler._reconcilePrimitiveChildren(instanceHandle, newElement)
@@ -372,8 +387,10 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 	elseif isStatefulElement(newElement) then
 		instanceHandle._element = newElement
 
-		-- Stateful elements can take care of themselves.
-		instanceHandle._instance:_update(newElement.props)
+		schedule(function()
+			-- Stateful elements can take care of themselves.
+			instanceHandle._instance:_update(newElement.props)
+		end)
 
 		return instanceHandle
 	elseif isPortal(newElement) then

--- a/lib/SyncScheduler.lua
+++ b/lib/SyncScheduler.lua
@@ -1,0 +1,20 @@
+local SyncScheduler = {}
+SyncScheduler.__index = SyncScheduler
+
+function SyncScheduler.new()
+	local self = setmetatable({}, SyncScheduler)
+
+	return self
+end
+
+function SyncScheduler:schedule(task)
+	task()
+end
+
+function SyncScheduler:destruct()
+end
+
+function SyncScheduler:flush()
+end
+
+return SyncScheduler


### PR DESCRIPTION
This is a small experiment to retrofit some asynchronous rendering onto Roact by means of creating (and swapping) implementations of a 'scheduler', a new concept.

The changes are fairly conservative to try to ensure that as much existing code using Roact will still work with this prototype.