### PR TITLE
Made elements a single table instead of two.

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -244,7 +244,7 @@ end
 	elementTracing configuration flag is set to false.
 ]]
 function Component:getElementTraceback()
-	return self._handle._element.source
+	return self._handle._element[Core.Source]
 end
 
 --[[

--- a/lib/Core.lua
+++ b/lib/Core.lua
@@ -21,4 +21,10 @@ Core.None = Symbol.named("None")
 -- Marker used to specify that the table it is present within is a component.
 Core.Element = Symbol.named("Element")
 
+-- Marker used to specify the component of an element.
+Core.Type = Symbol.named("Type")
+
+-- Marker used to specify stack trace of where an element was created.
+Core.Source = Symbol.named("Element")
+
 return Core

--- a/lib/Instrumentation.lua
+++ b/lib/Instrumentation.lua
@@ -18,6 +18,8 @@
 		- Percent of total shouldUpdate time by component
 ]]
 
+local Core = require(script.Parent.Core)
+
 local Instrumentation = {}
 
 local componentStats = {}
@@ -28,8 +30,8 @@ local componentStats = {}
 ]]
 local function getStatEntry(handle)
 	local name
-	if handle and handle._element and handle._element.component then
-		name = tostring(handle._element.component)
+	if handle and handle._element and handle._element[Core.Type] then
+		name = tostring(handle._element[Core.Type])
 	else
 		warn("Component name not valid for " .. tostring(handle._key))
 		return nil

--- a/lib/createElement.lua
+++ b/lib/createElement.lua
@@ -6,29 +6,27 @@ local GlobalConfig = require(script.Parent.GlobalConfig)
 
 	Does not create any concrete objects.
 ]]
-local function createElement(elementType, props, children)
-	if elementType == nil then
-		error(("Expected elementType as an argument to createElement!"), 2)
-	end
+local function createElement(elementType, element, children)
+	element = element or {}
 
-	props = props or {}
-
-	if children then
-		if props[Core.Children] ~= nil then
-			warn("props[Children] was defined but was overridden by third parameter to createElement!")
+	if elementType then
+		if element[Core.Type] then
+			warn("element[Type] was defined but was overriden by createElement!")
 		end
 
-		props[Core.Children] = children
+		element[Core.Type] = elementType
 	end
 
-	local element = {
-		type = Core.Element,
-		component = elementType,
-		props = props,
-	}
+	if children then
+		if element[Core.Children] then
+			warn("element[Children] was defined but was overridden by third parameter to createElement!")
+		end
+
+		element[Core.Children] = children
+	end
 
 	if GlobalConfig.getValue("elementTracing") then
-		element.source = ("\n%s\n"):format(debug.traceback())
+		element[Core.Source] = ("\n%s\n"):format(debug.traceback())
 	end
 
 	return element

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -26,6 +26,8 @@ return function()
 			None = true,
 			Element = true,
 			UNSTABLE = true,
+			Type = true,
+			Source = true,
 		}
 
 		expect(Roact).to.be.ok()


### PR DESCRIPTION
Partially Closes #109 

While this pull request does not remove createElement or remove element.source, it does move all element properties (component type and source) into the properties, allowing elements to be represented by one table.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [ ] Added/updated documentation