### PR TITLE
Pcall once per props instead of prop

### DIFF
--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -34,7 +34,7 @@ local Symbol = require(script.Parent.Symbol)
 
 local isInstanceHandle = Symbol.named("isInstanceHandle")
 
-local DEFAULT_SOURCE = "\n\t<Use Roact.setGlobalConfig with the 'elementTracing' key to enable detailed tracebacks>\n"
+local DEFAULT_SOURCE = "\t<Use Roact.setGlobalConfig with the 'elementTracing' key to enable detailed tracebacks>"
 
 local function isPortal(element)
 	if type(element) ~= "table" then


### PR DESCRIPTION
Refactored the _reconcilePrimitiveProps, it was using a table called 'seenProps' when it didn't need to be. Also made it submit batches of props to change in a call to _setRbxProps (previously _setRbxProp). _mountInternal now also uses _setRbxProps. _setRbxProp shouldn't ever error, but will warn if setting a property wasn't successful and continue onto the next properties. Not only did I run the tests, but I made a couple custom tests myself and verified that the output looks pretty.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [ ] Added/updated documentation