### PR TITLE
Resolved PureComponent render issue when using defaultProps

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -298,23 +298,6 @@ function Component:_forceUpdate(newProps, newState)
 				newState = merge(newState or self.state, derivedState)
 			end
 		end
-
-		if class.defaultProps then
-			-- We only allocate another prop table if there are props that are
-			-- falling back to their default.
-			local replacementProps
-
-			for key in pairs(class.defaultProps) do
-				if newProps[key] == nil then
-					replacementProps = merge(class.defaultProps, newProps)
-					break
-				end
-			end
-
-			if replacementProps then
-				newProps = replacementProps
-			end
-		end
 	end
 
 	if self.willUpdate then

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -228,11 +228,6 @@ return function()
 			bar = "world",
 		}
 
-		function TestComponent:shouldUpdate(newProps)
-			lastProps = newProps
-			return true
-		end
-
 		function TestComponent:render()
 			lastProps = self.props
 			return nil
@@ -267,6 +262,15 @@ return function()
 		expect(lastProps.bar).to.equal(false)
 
 		Reconciler.unmount(handle)
+
+		function TestComponent:shouldUpdate(newProps)
+			lastProps = newProps
+			return true
+		end
+
+		function TestComponent:render()
+			return nil
+		end
 
 		lastProps = nil;
 		handle = Reconciler.mount(createElement(TestComponent, {}))

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -228,6 +228,11 @@ return function()
 			bar = "world",
 		}
 
+		function TestComponent:shouldUpdate(newProps)
+			lastProps = newProps
+			return true
+		end
+
 		function TestComponent:render()
 			lastProps = self.props
 			return nil
@@ -260,6 +265,19 @@ return function()
 		expect(lastProps).to.be.a("table")
 		expect(lastProps.foo).to.equal("hello")
 		expect(lastProps.bar).to.equal(false)
+
+		Reconciler.unmount(handle)
+
+		lastProps = nil;
+		handle = Reconciler.mount(createElement(TestComponent, {}))
+		Reconciler.reconcile(handle, createElement(TestComponent, {
+			baz = "!",
+		}))
+
+		expect(lastProps).to.be.a("table")
+		expect(lastProps.foo).to.equal("hello")
+		expect(lastProps.bar).to.equal("world")
+		expect(lastProps.baz).to.equal("!")
 
 		Reconciler.unmount(handle)
 	end)

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -262,6 +262,16 @@ return function()
 		expect(lastProps.bar).to.equal(false)
 
 		Reconciler.unmount(handle)
+	end)
+
+	it("should include defaultProps in props passed to shouldUpdate", function()
+		local lastProps
+		local TestComponent = Component:extend("TestComponent")
+
+		TestComponent.defaultProps = {
+			foo = "hello",
+			bar = "world",
+		}
 
 		function TestComponent:shouldUpdate(newProps)
 			lastProps = newProps
@@ -272,8 +282,7 @@ return function()
 			return nil
 		end
 
-		lastProps = nil;
-		handle = Reconciler.mount(createElement(TestComponent, {}))
+		local handle = Reconciler.mount(createElement(TestComponent, {}))
 		Reconciler.reconcile(handle, createElement(TestComponent, {
 			baz = "!",
 		}))

--- a/lib/createElement.lua
+++ b/lib/createElement.lua
@@ -1,24 +1,6 @@
 local Core = require(script.Parent.Core)
 local GlobalConfig = require(script.Parent.GlobalConfig)
 
-local function merge(...) -- DRY, more like Do rWhatever, YOLO
-	local result = {}
-
-	for i = 1, select("#", ...) do
-		local entry = select(i, ...)
-
-		for key, value in pairs(entry) do
-			if value == Core.None then
-				result[key] = nil
-			else
-				result[key] = value
-			end
-		end
-	end
-
-	return result
-end
-
 --[[
 	Creates a new Roact element of the given type.
 
@@ -37,17 +19,6 @@ local function createElement(elementType, props, children)
 		end
 
 		props[Core.Children] = children
-	end
-
-	if elementType.defaultProps then -- I have no idea what I'm doing
-		-- We only allocate another prop table if there are props that are
-		-- falling back to their default.
-		for key in pairs(elementType.defaultProps) do
-			if props[key] == nil then
-				props = merge(elementType.defaultProps, props)
-				break
-			end
-		end
 	end
 
 	local element = {

--- a/lib/createElement.lua
+++ b/lib/createElement.lua
@@ -1,6 +1,24 @@
 local Core = require(script.Parent.Core)
 local GlobalConfig = require(script.Parent.GlobalConfig)
 
+local function merge(...) -- DRY, more like Do rWhatever, YOLO
+	local result = {}
+
+	for i = 1, select("#", ...) do
+		local entry = select(i, ...)
+
+		for key, value in pairs(entry) do
+			if value == Core.None then
+				result[key] = nil
+			else
+				result[key] = value
+			end
+		end
+	end
+
+	return result
+end
+
 --[[
 	Creates a new Roact element of the given type.
 
@@ -19,6 +37,17 @@ local function createElement(elementType, props, children)
 		end
 
 		props[Core.Children] = children
+	end
+
+	if elementType.defaultProps then -- I have no idea what I'm doing
+		-- We only allocate another prop table if there are props that are
+		-- falling back to their default.
+		for key in pairs(elementType.defaultProps) do
+			if props[key] == nil then
+				props = merge(elementType.defaultProps, props)
+				break
+			end
+		end
 	end
 
 	local element = {


### PR DESCRIPTION
Fixed bug with defaultProps not being included in newProps when passed into component's shouldUpdate method, causing components to rerender when unnecessary