### PR TITLE
Remove duplicated code in instrumentation checks

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -290,16 +290,12 @@ function Component:_update(newProps, newState)
 		end
 	end
 
-	local doUpdate
+	local startTime = tick()
+	local doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
+	local elapsed = tick() - startTime
+
 	if GlobalConfig.getValue("componentInstrumentation") then
-		local startTime = tick()
-
-		doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
-
-		local elapsed = tick() - startTime
 		Instrumentation.logShouldUpdate(self._handle, doUpdate, elapsed)
-	else
-		doUpdate = self:shouldUpdate(newProps or self.props, newState or self.state)
 	end
 
 	self._setStateBlockedReason = nil
@@ -382,16 +378,12 @@ function Component:_mount(handle)
 
 	self._setStateBlockedReason = "render"
 
-	local virtualTree
+	local startTime = tick()
+	local virtualTree = self:render()
+	local elapsed = tick() - startTime
+
 	if GlobalConfig.getValue("componentInstrumentation") then
-		local startTime = tick()
-
-		virtualTree = self:render()
-
-		local elapsed = tick() - startTime
 		Instrumentation.logRenderTime(self._handle, elapsed)
-	else
-		virtualTree = self:render()
 	end
 
 	self._setStateBlockedReason = nil


### PR DESCRIPTION
This code felt like a potential pitfall if one branch was modified but the other left untouched.

Checklist before submitting:
* [x] ~Added entry to `CHANGELOG.md`~
* [x] ~Added/updated relevant tests~
* [x] ~Added/updated documentation~

No functionality change should be observed.