### PR TITLE
Set up automated deployment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,3 +27,13 @@ script:
 
 after_success:
   - luacov-coveralls -e $TRAVIS_BUILD_DIR/lua_install
+  - mkdocs build
+
+deploy:
+  provider: pages
+  skip-cleanup: true
+  github-token: $GITHUB_TOKEN
+  keep-history: true
+  local_dir: site
+  on:
+    branch: master


### PR DESCRIPTION
Closes #121.

This will automatically deploy from Travis CI whenever a new commit is pushed to the `master` branch. **This PR is not valid right now!** Someone with commit access needs to generate a [personal access token](https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/) and add it to the Travis environment variables as `$GITHUB_TOKEN`. Once that's done this should be good to go!