### PR TITLE
Refactor SingleEventManager

### DIFF
--- a/lib/SingleEventManager.spec.lua
+++ b/lib/SingleEventManager.spec.lua
@@ -191,7 +191,7 @@ return function()
 
 		it("should succeed with no events attached", function()
 			local manager = SingleEventManager.new()
-			local target = Instance.new("StringValue")
+			local target = Instance.new("BindableEvent")
 
 			manager:disconnect(target, "Event")
 		end)


### PR DESCRIPTION
This PR should make SingleEventManager a little bit tidier. Instead of indexing by string keys, the internal event table is indexed by the event objects themselves.

Additionally, this refactored `SingleEventManager` uses an indirection trick to make replacing an existing connection much quicker. When connecting to an event that's already connected, we can just update a member in a table instead of disconnect/reconnecting a signal.

This PR relies on the idea that `GetPropertyChangedSignal` will always return the same signal every time it's called, since we use it for object identity.

Checklist before submitting:
* [x] Not user-facing change
* [x] Added/updated relevant tests