### PR TITLE
Refactor init to explicitly lay out APIs instead of being dynamic

### DIFF
--- a/lib/init.lua
+++ b/lib/init.lua
@@ -9,6 +9,14 @@ local Reconciler = require(script.Reconciler)
 local ReconcilerCompat = require(script.ReconcilerCompat)
 
 local Roact = {
+	Change = require(script.Change),
+	Component = require(script.Component),
+	createElement = require(script.createElement),
+	createRef = require(script.createRef),
+	Event = require(script.Event),
+	oneChild = require(script.oneChild),
+	PureComponent = require(script.PureComponent),
+
 	Children = Core.Children,
 	Element = Core.Element,
 	None = Core.None,
@@ -24,14 +32,6 @@ local Roact = {
 
 	setGlobalConfig = GlobalConfig.set,
 	getGlobalConfigValue = GlobalConfig.getValue,
-
-	Change = require(script.Change),
-	Component = require(script.Component),
-	createElement = require(script.createElement),
-	createRef = require(script.createRef),
-	Event = require(script.Event),
-	oneChild = require(script.oneChild),
-	PureComponent = require(script.PureComponent),
 
 	-- APIs that may change in the future without warning
 	UNSTABLE = {

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -2,65 +2,42 @@
 	Packages up the internals of Roact and exposes a public API for it.
 ]]
 
-local Change = require(script.Change)
-local Component = require(script.Component)
 local Core = require(script.Core)
-local createElement = require(script.createElement)
-local createRef = require(script.createRef)
-local Event = require(script.Event)
 local GlobalConfig = require(script.GlobalConfig)
 local Instrumentation = require(script.Instrumentation)
-local oneChild = require(script.oneChild)
-local PureComponent = require(script.PureComponent)
 local Reconciler = require(script.Reconciler)
 local ReconcilerCompat = require(script.ReconcilerCompat)
 
---[[
-	A utility to copy one module into another, erroring if there are
-	overlapping keys.
+local Roact = {
+	Children = Core.Children,
+	Element = Core.Element,
+	None = Core.None,
+	Portal = Core.Portal,
+	Ref = Core.Ref,
 
-	Any keys that begin with an underscore are considered private.
-]]
-local function apply(target, source)
-	for key, value in pairs(source) do
-		if target[key] ~= nil then
-			error(("Roact: key %q was overridden!"):format(key), 2)
-		end
+	mount = Reconciler.mount,
+	unmount = Reconciler.unmount,
+	reconcile = Reconciler.reconcile,
 
-		-- Don't add internal values
-		if not key:find("^_") then
-			target[key] = value
-		end
-	end
-end
+	reify = ReconcilerCompat.reify,
+	teardown = ReconcilerCompat.teardown,
 
-local Roact = {}
-
-apply(Roact, Core)
-apply(Roact, Reconciler)
-apply(Roact, ReconcilerCompat)
-
-apply(Roact, {
-	Change = Change,
-	Component = Component,
-	createElement = createElement,
-	createRef = createRef,
-	Event = Event,
-	oneChild = oneChild,
-	PureComponent = PureComponent,
-})
-
-apply(Roact, {
 	setGlobalConfig = GlobalConfig.set,
 	getGlobalConfigValue = GlobalConfig.getValue,
-})
 
-apply(Roact, {
-	-- APIs that may change in the future
+	Change = require(script.Change),
+	Component = require(script.Component),
+	createElement = require(script.createElement),
+	createRef = require(script.createRef),
+	Event = require(script.Event),
+	oneChild = require(script.oneChild),
+	PureComponent = require(script.PureComponent),
+
+	-- APIs that may change in the future without warning
 	UNSTABLE = {
 		getCollectedStats = Instrumentation.getCollectedStats,
 		clearCollectedStats = Instrumentation.clearCollectedStats,
-	}
-})
+	},
+}
 
 return Roact


### PR DESCRIPTION
The dynamic construction of the Roact API has been problematic for awhile. It's really difficult for type inference to pick up the shape of the API, and it's harder to tell at a glance what all of the functions we export are.

This should not be a user-facing change, has not affected tests, and in general should be seamless.