### PR TITLE
Do Not Merge: Hack in bindings onto the reconciler

### DIFF
--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -116,6 +116,10 @@ function Reconciler.unmount(instanceHandle)
 		-- Necessary to make sure SingleEventManager doesn't leak references
 		Reconciler._singleEventManager:disconnectAll(instanceHandle._rbx)
 
+		for _, binding in ipairs(instanceHandle._bindings) do
+			binding()
+		end
+
 		instanceHandle._rbx:Destroy()
 	elseif elementKind == ElementKind.Functional then
 		-- Functional components can return nil


### PR DESCRIPTION
This is an experiment to tinker with the ergonomics of introducing "bindings" -- special values that can be used with primitive elements to bypass the reconciler.

@cwlowder and I were curious to see if any problems pop up purely in their ergonomics, so I hacked them into the reconciler with the minimal set of code changes required.

The interface Roact expects for a binding in this PR is a table with:

* `current`: The current value the binding is set to
* `subscribe`: A function that adds a listener to the binding, returning a disconnect function

As a hack, I added a new member to instance handles named `_bindings` that keeps track of each binding by key. Transitions to and from bindings _should_ work correctly, but I haven't tested any of this code.