### PR TITLE
Warn on element type change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 * Added `defaultProps` value on stateful components to define values for props that aren't specified ([#79](https://github.com/Roblox/roact/pull/79))
 * Added `getElementTraceback` ([#81](https://github.com/Roblox/roact/issues/81), [#93](https://github.com/Roblox/roact/pull/93))
 * Added `createRef` ([#70](https://github.com/Roblox/roact/issues/70), [#92](https://github.com/Roblox/roact/pull/92))
+* Added a warning when an element changes type during reconciliation ([#88](https://github.com/Roblox/roact/issues/88), [#137](https://github.com/Roblox/roact/pull/137))
 * Ref switching now occurs in one pass, which should fix edge cases where the result of a ref is `nil`, especially in property changed events ([#98](https://github.com/Roblox/roact/pull/98))
 
 ## 1.0.0 Prerelease 2 (March 22, 2018)

--- a/lib/Config.lua
+++ b/lib/Config.lua
@@ -18,6 +18,8 @@ local defaultConfig = {
 	["elementTracing"] = false,
 	-- Enables instrumentation of shouldUpdate and render methods for Roact components
 	["componentInstrumentation"] = false,
+	-- Enables warnings if an element changes type after being rendered.
+	["warnOnTypeChange"] = true,
 }
 
 -- Build a list of valid configuration values up for debug messages.

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -319,7 +319,8 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 	-- different. This lets us skip comparisons of a large swath of nodes.
 	if oldElement.component ~= newElement.component then
 		if GlobalConfig.getValue("warnOnTypeChange") then
-			warn(("A Roact component is changing type from %s to %s during reconciliation! This can cause performance issues; see issue #88 for details."):format(
+			warn(("A Roact component is changing type from %s to %s during reconciliation!\n"
+				.. "This can cause performance issues; see issue #88 for details."):format(
 				tostring(oldElement.component),
 				tostring(newElement.component)
 			))

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -317,6 +317,16 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 	-- If the element changes type, we assume its subtree will be substantially
 	-- different. This lets us skip comparisons of a large swath of nodes.
 	if oldElement.component ~= newElement.component then
+		warn(("A Roact component is changing type from %s to %s during reconciliation! This can cause performance issues; see issue #88 for details."):format(
+			tostring(oldElement.component),
+			tostring(newElement.component)
+		))
+
+		print(("Old element source: %s\nNew element source: %s"):format(
+			oldElement.source or DEFAULT_SOURCE,
+			newElement.source or DEFAULT_SOURCE
+		))
+
 		local parent = instanceHandle._parent
 		local key = instanceHandle._key
 

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -31,6 +31,7 @@ local Change = require(script.Parent.Change)
 local getDefaultPropertyValue = require(script.Parent.getDefaultPropertyValue)
 local SingleEventManager = require(script.Parent.SingleEventManager)
 local Symbol = require(script.Parent.Symbol)
+local GlobalConfig = require(script.Parent.GlobalConfig)
 
 local isInstanceHandle = Symbol.named("isInstanceHandle")
 
@@ -317,15 +318,17 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 	-- If the element changes type, we assume its subtree will be substantially
 	-- different. This lets us skip comparisons of a large swath of nodes.
 	if oldElement.component ~= newElement.component then
-		warn(("A Roact component is changing type from %s to %s during reconciliation! This can cause performance issues; see issue #88 for details."):format(
-			tostring(oldElement.component),
-			tostring(newElement.component)
-		))
+		if GlobalConfig.getValue("warnOnTypeChange") then
+			warn(("A Roact component is changing type from %s to %s during reconciliation! This can cause performance issues; see issue #88 for details."):format(
+				tostring(oldElement.component),
+				tostring(newElement.component)
+			))
 
-		print(("Old element source: %s\nNew element source: %s"):format(
-			oldElement.source or DEFAULT_SOURCE,
-			newElement.source or DEFAULT_SOURCE
-		))
+			print(("Old element source: %s\nNew element source: %s"):format(
+				oldElement.source or DEFAULT_SOURCE,
+				newElement.source or DEFAULT_SOURCE
+			))
+		end
 
 		local parent = instanceHandle._parent
 		local key = instanceHandle._key


### PR DESCRIPTION
Closes #88.

This will throw a warning during reconciliation if a component type has changed. It will output stack traces of the two components involved, old and new. In cases where these warnings are unwelcome, they can be disabled by setting the configuration key `warnOnTypeChange` to `false` (defaults to `true`).

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* Test changes aren't feasible
* No documentation changes made