### PR TITLE
Rewrite Ref page in advanced guide

### DIFF
--- a/docs/advanced/refs.md
+++ b/docs/advanced/refs.md
@@ -3,7 +3,7 @@
 Refs are intended to be used in cases where Roact cannot solve a problem directly, or its solution might not be performant enough, like:
 
 * Resizing a box to fit its contents dynamically
-* Handling gamepad selection
+* Gamepad selection
 * Animations
 
 Refs can only be attached to primitive components. This is different than React, where refs can be used to call members of composite components.


### PR DESCRIPTION
The current guide page is kind of a jumble between functional and object refs.

I tried to make it more clear by focusing on introducing object refs and moving function refs to be basically a footnote.

Checklist before submitting:
* ~Added entry to `CHANGELOG.md`~
* ~Added/updated relevant tests~
* [x] Added/updated documentation