### PR TITLE
WIP: Implement event suspension to try to make listener behavior more intuitive

### DIFF
--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -166,6 +166,8 @@ function Reconciler._mountInternal(element, parent, key, context)
 
 		local rbx = Instance.new(element.component)
 
+		Reconciler._singleEventManager:suspendEvents(rbx)
+
 		-- Update Roblox properties
 		for key, value in pairs(element.props) do
 			Reconciler._setRbxProp(rbx, key, value, element)
@@ -194,6 +196,8 @@ function Reconciler._mountInternal(element, parent, key, context)
 
 		-- Attach ref values, since the instance is initialized now.
 		applyRef(element.props[Core.Ref], rbx)
+
+		Reconciler._singleEventManager:resumeEvents(rbx)
 
 		return {
 			[isInstanceHandle] = true,
@@ -349,6 +353,8 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 	end
 
 	if newElementKind == ElementKind.Primitive then
+		Reconciler._singleEventManager:suspendEvents(instanceHandle._rbx)
+
 		local oldRef = oldElement.props[Core.Ref]
 		local newRef = newElement.props[Core.Ref]
 
@@ -365,6 +371,8 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 		Reconciler._reconcilePrimitiveChildren(instanceHandle, newElement)
 
 		instanceHandle._element = newElement
+
+		Reconciler._singleEventManager:resumeEvents(instanceHandle._rbx)
 
 		return instanceHandle
 	elseif newElementKind == ElementKind.Functional then


### PR DESCRIPTION
I don't know if this is the right approach, but I'd like to commit this to a branch and see if it sticks.

The idea here is that while Roact is in the 'commit' phase (actually mutating elements) we should suspend listeners until we get out of the commit phase. The original goal was to reduce the amount of times we have to call `spawn` or `delay` inside of changed listeners that want to call `setState`, but now that I've implemented it, I see that this doesn't help.

Instead, perhaps the best approach is to make `setState` specifically not apply until after the commit phase is over. That way, we have knowledge at the level of the stateful component instead of trying to infer some lifecycle from inside the commit method of a primitive/host component.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation