### PR TITLE
WIP: Events for new reconciler

### DIFF
--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -147,6 +147,11 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 	virtualNode.hostObject = instance
 
 	applyRef(element.props[Ref], instance)
+
+	-- Enable event handling only when we're done with mounting
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:resume()
+	end
 end
 
 function RobloxRenderer.unmountHostNode(reconciler, virtualNode)
@@ -166,6 +171,11 @@ end
 function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 	local oldProps = virtualNode.currentElement.props
 	local newProps = newElement.props
+
+	-- Suspend event listeners for the node so we don't get events firing during reconciliation
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:suspend()
+	end
 
 	-- If refs changed, detach the old ref and attach the new one
 	if oldProps[Ref] ~= newProps[Ref] then
@@ -190,6 +200,11 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 	end
 
 	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
+
+	-- Resume event firing now that everything's updated successfully
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:resume()
+	end
 
 	return virtualNode
 end

--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -91,9 +91,9 @@ local function applyProp(virtualNode, key, newValue, oldValue)
 		local eventName = key.name
 
 		if internalKeyType == Type.HostChangeEvent then
-			virtualNode.eventManager:connectEvent(eventName, newValue)
-		else
 			virtualNode.eventManager:connectPropertyChange(eventName, newValue)
+		else
+			virtualNode.eventManager:connectEvent(eventName, newValue)
 		end
 
 		return

--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -7,6 +7,7 @@
 local Binding = require(script.Parent.Binding)
 local Children = require(script.Parent.PropMarkers.Children)
 local ElementKind = require(script.Parent.ElementKind)
+local SingleEventManager = require(script.Parent.SingleEventManager)
 local getDefaultInstanceProperty = require(script.Parent.getDefaultInstanceProperty)
 local Ref = require(script.Parent.PropMarkers.Ref)
 local Type = require(script.Parent.Type)
@@ -83,7 +84,18 @@ local function applyProp(virtualNode, key, newValue, oldValue)
 	local internalKeyType = Type.of(key)
 
 	if internalKeyType == Type.HostEvent or internalKeyType == Type.HostChangeEvent then
-		-- TODO: Apply events
+		if virtualNode.eventManager == nil then
+			virtualNode.eventManager = SingleEventManager.new(virtualNode.hostObject)
+		end
+
+		local eventName = key.name
+
+		if internalKeyType == Type.HostChangeEvent then
+			virtualNode.eventManager:connectEvent(eventName, newValue)
+		else
+			virtualNode.eventManager:connectPropertyChange(eventName, newValue)
+		end
+
 		return
 	end
 

--- a/lib/SingleEventManager.lua
+++ b/lib/SingleEventManager.lua
@@ -79,7 +79,7 @@ function SingleEventManagerPrototype:resume()
 		local record = self._queue[i]
 		local listener = self._listeners[record[1]]
 		local count = record[2]
-		listener(self._instance, unpack(record, 3))
+		listener(self._instance, unpack(record, 3, count))
 	end
 
 	self._queue = {}

--- a/lib/SingleEventManager.lua
+++ b/lib/SingleEventManager.lua
@@ -57,9 +57,8 @@ function SingleEventManagerPrototype:_connect(eventKey, event, listener)
 				if self._state == SingleEventManager.SuspensionStatus.Enabled then
 					self._listeners[eventKey](self._instance, ...)
 				elseif self._state == SingleEventManager.SuspensionStatus.Suspended then
-					-- Store event key (so we know which listener to invoke), count of arguments (so unpack())
-					-- doesn't freak out with nils), and finally the arguments themselves.
-					table.insert(self._queue, { eventKey, select("#", ...), ... })
+					-- Store event key (so we know which listener to invoke) along with the arguments.
+					table.insert(self._queue, { eventKey, ... })
 				end
 			end)
 		end
@@ -79,7 +78,7 @@ function SingleEventManagerPrototype:resume()
 		local record = self._queue[i]
 		local listener = self._listeners[record[1]]
 		local count = record[2]
-		listener(self._instance, unpack(record, 3, count))
+		listener(self._instance, unpack(record, 2))
 	end
 
 	self._queue = {}


### PR DESCRIPTION
Events for the new reconciler :tada:

Host virtual nodes will start handling events whenever an event is first used in the virtual node. If your node is static and has no events in its lifecycle, the event machinery is never set up. Events won't be fired at all during the initial mount process; any events fired in the middle of subsequent updates are queued and fired after the update is completed.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] More comments for explanation/internal documentation?
* Documentation updates aren't necessary, since this feature's already documented!