### PR TITLE
New Reconciler: Fix possible error when processing boolean element

### DIFF
--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -35,7 +35,11 @@ local function createReconciler(renderer)
 
 		unmountVirtualNode(virtualNode)
 		local newNode = mountVirtualNode(newElement, hostParent, hostKey)
-		newNode.depth = depth
+
+		-- mountVirtualNode can return nil if the element is a boolean
+		if newNode ~= nil then
+			newNode.depth = depth
+		end
 
 		return newNode
 	end
@@ -74,8 +78,12 @@ local function createReconciler(renderer)
 
 			if virtualNode.children[childKey] == nil then
 				local childNode = mountVirtualNode(newElement, hostParent, concreteKey, virtualNode.context)
-				childNode.depth = virtualNode.depth + 1
-				virtualNode.children[childKey] = childNode
+
+				-- mountVirtualNode can return nil if the element is a boolean
+				if childNode ~= nil then
+					childNode.depth = virtualNode.depth + 1
+					virtualNode.children[childKey] = childNode
+				end
 			end
 		end
 	end


### PR DESCRIPTION
Discovered this issue in the new reconciler when pointing it at a large existing project.

When we return a boolean as an element, mounting it will result in a nil virtual node. This is by design, but the `updateVirtualNodeChildren` function fails to account for it. Maybe there's a better place to account for this, or it can be resolved by updating depth information elsewhere?

Additionally, the `replaceVirtualNode` case doesn't appear to be technically possible, because it should always short-circuit beforehand.

~~I haven't yet written a regression test for this, but it should boil down to rendering an element tree in which a node below the root resolves to a boolean.~~

This is a pain to do with the NoopRenderer, and it feels weird to use the RobloxRenderer just to test the regression here, especially since the broken code has never been live anyway.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* ~~Added/updated relevant tests~~
* ~~Added/updated documentation~~