### PR TITLE
New Reconciler: Fix case where context is not passed.

### DIFF
--- a/lib/Component.spec/context.spec.lua
+++ b/lib/Component.spec/context.spec.lua
@@ -140,10 +140,70 @@ return function()
 		assertDeepEqual(capturedContext, expectedContext)
 	end)
 
-	itSKIP("should transfer context to children that are replaced", function()
-		-- TODO: Write a test that
-		-- 1. Renders a component tree with a context consumer component
-		-- 2. Updates that tree with a different consumer component at the same key
-		-- 3. Confirm that context captured from initial consumer deep-equals context captured from new consumer
+	it("should transfer context to children that are replaced", function()
+		local ConsumerA = Component:extend("ConsumerA")
+
+		local capturedContextA
+		function ConsumerA:init()
+			self._context.A = "hello"
+
+			capturedContextA = self._context
+		end
+
+		function ConsumerA:render()
+		end
+
+		local ConsumerB = Component:extend("ConsumerB")
+
+		local capturedContextB
+		function ConsumerB:init()
+			self._context.B = "hello"
+
+			capturedContextB = self._context
+		end
+
+		function ConsumerB:render()
+		end
+
+		local Provider = Component:extend("Provider")
+
+		function Provider:init()
+			self._context.frob = "ulator"
+		end
+
+		function Provider:render()
+			local useConsumerB = self.props.useConsumerB
+
+			if useConsumerB then
+				return createElement(ConsumerB)
+			else
+				return createElement(ConsumerA)
+			end
+		end
+
+		local hostParent = nil
+		local hostKey = "Consumer"
+
+		local element = createElement(Provider)
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey)
+
+		local expectedContextA = {
+			frob = "ulator",
+			A = "hello",
+		}
+
+		assertDeepEqual(capturedContextA, expectedContextA)
+
+		local expectedContextB = {
+			frob = "ulator",
+			B = "hello",
+		}
+
+		local replacedElement = createElement(Provider, {
+			useConsumerB = true,
+		})
+		noopReconciler.updateVirtualNode(node, replacedElement)
+
+		assertDeepEqual(capturedContextB, expectedContextB)
 	end)
 end

--- a/lib/Component.spec/context.spec.lua
+++ b/lib/Component.spec/context.spec.lua
@@ -139,4 +139,11 @@ return function()
 		assertDeepEqual(node.context, expectedContext)
 		assertDeepEqual(capturedContext, expectedContext)
 	end)
+
+	itSKIP("should transfer context to children that are replaced", function()
+		-- TODO: Write a test that
+		-- 1. Renders a component tree with a context consumer component
+		-- 2. Updates that tree with a different consumer component at the same key
+		-- 3. Confirm that context captured from initial consumer deep-equals context captured from new consumer
+	end)
 end

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -28,13 +28,14 @@ local function createReconciler(renderer)
 
 		Preserves host properties and depth.
 	]]
-	local function replaceVirtualNode(virtualNode, newElement, parentContext)
+	local function replaceVirtualNode(virtualNode, newElement)
 		local hostParent = virtualNode.hostParent
 		local hostKey = virtualNode.hostKey
 		local depth = virtualNode.depth
+		local context = virtualNode.context
 
 		unmountVirtualNode(virtualNode)
-		local newNode = mountVirtualNode(newElement, hostParent, hostKey, parentContext)
+		local newNode = mountVirtualNode(newElement, hostParent, hostKey, context)
 		newNode.depth = depth
 
 		return newNode
@@ -52,7 +53,7 @@ local function createReconciler(renderer)
 		-- Changed or removed children
 		for childKey, childNode in pairs(virtualNode.children) do
 			local newElement = ChildUtils.getChildByKey(newChildElements, childKey)
-			local newNode = updateVirtualNode(childNode, newElement, nil, virtualNode.context)
+			local newNode = updateVirtualNode(childNode, newElement)
 
 			if newNode ~= nil then
 				virtualNode.children[childKey] = newNode
@@ -113,7 +114,7 @@ local function createReconciler(renderer)
 		return virtualNode
 	end
 
-	local function updatePortalVirtualNode(virtualNode, newElement, context)
+	local function updatePortalVirtualNode(virtualNode, newElement)
 		local oldElement = virtualNode.currentElement
 		local oldTargetHostParent = oldElement.props.target
 
@@ -126,7 +127,7 @@ local function createReconciler(renderer)
 			-- TODO: Better warning
 			Logging.warn("Portal changed target!")
 
-			return replaceVirtualNode(virtualNode, newElement, context)
+			return replaceVirtualNode(virtualNode, newElement)
 		end
 
 		local children = newElement.props[Children]
@@ -148,7 +149,7 @@ local function createReconciler(renderer)
 		mount a new virtual node, and return it in this case, while also issuing
 		a warning to the user.
 	]]
-	function updateVirtualNode(virtualNode, newElement, newState, context)
+	function updateVirtualNode(virtualNode, newElement, newState)
 		assert(Type.of(virtualNode) == Type.VirtualNode)
 		assert(Type.of(newElement) == Type.Element or typeof(newElement) == "boolean" or newElement == nil)
 
@@ -166,7 +167,7 @@ local function createReconciler(renderer)
 			-- TODO: Better message
 			Logging.warn("Component changed type!")
 
-			return replaceVirtualNode(virtualNode, newElement, context)
+			return replaceVirtualNode(virtualNode, newElement)
 		end
 
 		local kind = ElementKind.of(newElement)

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -32,9 +32,10 @@ local function createReconciler(renderer)
 		local hostParent = virtualNode.hostParent
 		local hostKey = virtualNode.hostKey
 		local depth = virtualNode.depth
+		local context = virtualNode.context
 
 		unmountVirtualNode(virtualNode)
-		local newNode = mountVirtualNode(newElement, hostParent, hostKey)
+		local newNode = mountVirtualNode(newElement, hostParent, hostKey, context)
 		newNode.depth = depth
 
 		return newNode

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -32,7 +32,7 @@ local function createReconciler(renderer)
 		local hostParent = virtualNode.hostParent
 		local hostKey = virtualNode.hostKey
 		local depth = virtualNode.depth
-		local context = virtualNode.context
+		local context = virtualNode.parentContext
 
 		unmountVirtualNode(virtualNode)
 		local newNode = mountVirtualNode(newElement, hostParent, hostKey, context)
@@ -218,6 +218,9 @@ local function createReconciler(renderer)
 			hostParent = hostParent,
 			hostKey = hostKey,
 			context = context,
+			-- This copy of context is useful if the element gets replaced
+			-- with an element of a different component type
+			parentContext = context,
 		}
 	end
 

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -26,16 +26,16 @@ local function createReconciler(renderer)
 		Unmount the given virtualNode, replacing it with a new node described by
 		the given element.
 
-		Preserves host properties and depth.
+		Preserves host properties, depth, and context from parent.
 	]]
 	local function replaceVirtualNode(virtualNode, newElement)
 		local hostParent = virtualNode.hostParent
 		local hostKey = virtualNode.hostKey
 		local depth = virtualNode.depth
-		local context = virtualNode.parentContext
+		local parentContext = virtualNode.parentContext
 
 		unmountVirtualNode(virtualNode)
-		local newNode = mountVirtualNode(newElement, hostParent, hostKey, context)
+		local newNode = mountVirtualNode(newElement, hostParent, hostKey, parentContext)
 		newNode.depth = depth
 
 		return newNode


### PR DESCRIPTION
Discovered this issue in the new reconciler when pointing it at a large existing project.

Context was not being carried over during an update if the component rendered with a given key was changed to a new component type (a case in which we currently warn, but expect everything to work fine).

Writing a regression test for this should be pretty straightforward, but requires several steps.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* [x] Added/updated relevant tests
* ~~Added/updated documentation~~