### PR TITLE
New Reconciler: boolean event fix

### DIFF
--- a/lib/SingleEventManager.lua
+++ b/lib/SingleEventManager.lua
@@ -59,7 +59,9 @@ end
 
 function SingleEventManager:_connect(eventKey, event, listener)
 	-- If the listener doesn't exist we can just disconnect the existing connection
-	if listener == nil then
+	-- We also treat boolean values as disconnections, the same way we allow boolean
+	-- elements to represent absent elements
+	if typeof(listener) == "boolean" or listener == nil then
 		if self._connections[eventKey] ~= nil then
 			self._connections[eventKey]:Disconnect()
 			self._connections[eventKey] = nil

--- a/lib/SingleEventManager.spec.lua
+++ b/lib/SingleEventManager.spec.lua
@@ -36,6 +36,20 @@ return function()
 			expect(eventSpy.callCount).to.equal(2)
 		end)
 
+		it("should treat boolean values as nil and disconnect the event", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+			local eventSpy = createSpy()
+
+			manager:connectEvent("Event", eventSpy.value)
+			manager:resume()
+
+			manager:connectEvent("Event", false)
+
+			instance:Fire("foo")
+			expect(eventSpy.callCount).to.equal(0)
+		end)
+
 		it("should drop events until resumed initially", function()
 			local instance = Instance.new("BindableEvent")
 			local manager = SingleEventManager.new(instance)


### PR DESCRIPTION
Fixes slight functionality divergence; the old reconciler let users set [Roact.Event.Whatever] properties to a boolean, which would behave the same way as disconnecting or not connecting them (similar to boolean elements).

Note that the old code does this outside of the event manager, in the reconciler itself. Because of the way the connections were refactored to connect/connect-with-nil instead of connect/disconnect, it seemed to make more sense for the event manager to be the one to support it.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* [x] Added/updated relevant tests
* ~~Added/updated documentation~~