### PR TITLE
Change the default value for warnings on element type changes to 'false'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 * Ref switching now occurs in one pass, which should fix edge cases where the result of a ref is `nil`, especially in property changed events ([#98](https://github.com/Roblox/roact/pull/98))
 * `setState` can now be called inside `init` and `willUpdate`. Instead of triggering a new render, it will affect the currently scheduled one. ([#139](https://github.com/Roblox/roact/pull/139))
 * Roll back changes that allowed `setState` to be called inside `willUpdate`, which created state update scenarios with difficult-to-determine behavior. ([#157](https://github.com/Roblox/roact/pull/157))
+* By default, disable the warning for an element changing types during reconciliation ([#168](https://github.com/Roblox/roact/pull/168))
 
 ## 1.0.0 Prerelease 2 (March 22, 2018)
 * Removed `is*Element` methods, this is unlikely to affect anyone ([#50](https://github.com/Roblox/roact/pull/50))

--- a/lib/Config.lua
+++ b/lib/Config.lua
@@ -19,7 +19,7 @@ local defaultConfig = {
 	-- Enables instrumentation of shouldUpdate and render methods for Roact components
 	["componentInstrumentation"] = false,
 	-- Enables warnings if an element changes type after being rendered.
-	["warnOnTypeChange"] = true,
+	["warnOnTypeChange"] = false,
 }
 
 -- Build a list of valid configuration values up for debug messages.


### PR DESCRIPTION
This change reflects our growing uncertainty about this being a valid warning in the first place.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* ~~Added/updated relevant tests~~
* ~~Added/updated documentation~~