### PR TITLE
New Reconciler: Fix scary bug in assertDeepEqual (testing utility)

### DIFF
--- a/lib/assertDeepEqual.lua
+++ b/lib/assertDeepEqual.lua
@@ -40,7 +40,7 @@ local function deepEqual(a, b)
 						:gsub("{1}", ("{1}[%s]"):format(tostring(key)))
 						:gsub("{2}", ("{2}[%s]"):format(tostring(key)))
 
-					return message
+					return false, message
 				end
 			end
 		end

--- a/lib/assertDeepEqual.spec.lua
+++ b/lib/assertDeepEqual.spec.lua
@@ -1,0 +1,99 @@
+return function()
+	local assertDeepEqual = require(script.Parent.assertDeepEqual)
+
+	it("should fail with a message when args are not equal", function()
+		local success, message = pcall(assertDeepEqual, 1, 2)
+
+		expect(success).to.equal(false)
+		expect(message:find("first ~= second")).to.be.ok()
+
+		success, message = pcall(assertDeepEqual, {
+			foo = 1,
+		}, {
+			foo = 2,
+		})
+
+		expect(success).to.equal(false)
+		expect(message:find("first%[foo%] ~= second%[foo%]")).to.be.ok()
+	end)
+
+	it("should compare non-table values using standard '==' equality", function()
+		assertDeepEqual(1, 1)
+		assertDeepEqual("hello", "hello")
+		assertDeepEqual(nil, nil)
+
+		local someFunction = function() end
+		local theSameFunction = someFunction
+
+		assertDeepEqual(someFunction, theSameFunction)
+
+		local A = {
+			foo = someFunction
+		}
+		local B = {
+			foo = theSameFunction
+		}
+
+		assertDeepEqual(A, B)
+	end)
+
+	it("should fail when types differ", function()
+		local success, message = pcall(assertDeepEqual, 1, "1")
+
+		expect(success).to.equal(false)
+		expect(message:find("first is of type number, but second is of type string")).to.be.ok()
+	end)
+
+	it("should compare (and report about) nested tables", function()
+		local A = {
+			foo = "bar",
+			nested = {
+				foo = 1,
+				bar = 2,
+			}
+		}
+		local B = {
+			foo = "bar",
+			nested = {
+				foo = 1,
+				bar = 2,
+			}
+		}
+
+		assertDeepEqual(A, B)
+
+		local C = {
+			foo = "bar",
+			nested = {
+				foo = 1,
+				bar = 3,
+			}
+		}
+
+		local success, message = pcall(assertDeepEqual, A, C)
+
+		expect(success).to.equal(false)
+		expect(message:find("first%[nested%]%[bar%] ~= second%[nested%]%[bar%]")).to.be.ok()
+	end)
+
+	it("should be commutative", function()
+		local equalArgsA = {
+			foo = "bar",
+			hello = "world",
+		}
+		local equalArgsB = {
+			foo = "bar",
+			hello = "world",
+		}
+
+		assertDeepEqual(equalArgsA, equalArgsB)
+		assertDeepEqual(equalArgsB, equalArgsA)
+
+		local nonEqualArgs = {
+			foo = "bar",
+		}
+
+		expect(function() assertDeepEqual(equalArgsA, nonEqualArgs) end).to.throw()
+		expect(function() assertDeepEqual(nonEqualArgs, equalArgsA) end).to.throw()
+	end)
+end


### PR DESCRIPTION
This bit me while I was trying to write tests for something else. I suppose now is a good time to write tests for assertDeepEqual...

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* [x] Added/updated relevant tests
* ~~Added/updated documentation~~