### PR TITLE
Allow any key type for element keys

### DIFF
--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -137,7 +137,7 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 		applyProp(virtualNode, propKey, value, nil)
 	end
 
-	instance.Name = hostKey
+	instance.Name = tostring(hostKey)
 
 	local children = element.props[Children]
 

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -202,7 +202,7 @@ local function createReconciler(renderer)
 	local function createVirtualNode(element, hostParent, hostKey, context)
 		assert(Type.of(element) == Type.Element or typeof(element) == "boolean")
 		assert(renderer.isHostObject(hostParent) or hostParent == nil)
-		assert(typeof(hostKey) == "string")
+		assert(hostKey ~= nil)
 		assert(typeof(context) == "table" or context == nil)
 
 		return {
@@ -246,7 +246,7 @@ local function createReconciler(renderer)
 	function mountVirtualNode(element, hostParent, hostKey, context)
 		assert(Type.of(element) == Type.Element or typeof(element) == "boolean")
 		assert(typeof(hostParent) == "Instance" or hostParent == nil)
-		assert(typeof(hostKey) == "string")
+		assert(hostKey ~= nil)
 		assert(typeof(context) == "table" or context == nil)
 
 		-- Boolean values render as nil to enable terse conditional rendering.
@@ -280,10 +280,9 @@ local function createReconciler(renderer)
 	local function mountVirtualTree(element, hostParent, hostKey)
 		assert(Type.of(element) == Type.Element)
 		assert(typeof(hostParent) == "Instance" or hostParent == nil)
-		assert(typeof(hostKey) == "string" or hostKey == nil)
-
+		
 		if hostKey == nil then
-			hostKey = "Foo"
+			hostKey = "RoactTree"
 		end
 
 		local tree = {


### PR DESCRIPTION
This fixes a compatibility issue between the old and new reconcilers, and also allows some more flexibility. It also changes the default tree root name from Foo to RoactTree.

Before this patch, the new reconciler would not allow elements to have a numerical key, which caused problems when mapping an array to children, or similar use cases. Now, values of any type are allowed for element keys; they will be converted to a string in the Roblox renderer.

This also allows increased flexibility for components that add (or modify) the children they receive. As an example, a ScrollingFrame component might want to add a list layout object to its children. To do this, it has to alter `props[Roact.Children]` to add it, and with that comes the possibility that an existing child might be clobbered:

```lua
local function ScrollingList(props)
    -- If there is a child already named UIListLayout, it will be clobbered!
    props[Roact.Children].UIListLayout = Roact.createElement("UIListLayout", {
        -- ...
    })

    return Roact.createElement("ScrollingFrame", {
        -- ...
    }, props[Roact.Children])
end
```

With this patch, we can use a private, unique value as the list layout's key, allowing children to be named whatever they want:

```lua
local listKey = Symbol.named("UIListLayout")

local function ScrollingList(props)
    -- Nothing outside of this component has access to listKey, so it's unique
    props[Roact.Children][listKey] = Roact.createElement("UIListLayout", {
        -- ...
    })

    return Roact.createElement("ScrollingFrame", {
        -- ...
    }, props[Roact.Children])
end
```