### PR TITLE
WIP: Fragments for new reconciler

### DIFF
--- a/lib/ChildUtils.lua
+++ b/lib/ChildUtils.lua
@@ -95,7 +95,13 @@ function ChildUtils.getChildByKey(elements, hostKey)
 		return nil
 	end
 
-	return elements[hostKey]
+	if Type.of(elements) == Type.Fragment then
+		return elements.elements[hostKey]
+	end
+
+	error("Invalid elements")
+	-- TODO: Let's fix this case; it should work for fragments(?), but not arbitrary tables
+	-- return elements[hostKey]
 end
 
 return ChildUtils

--- a/lib/ChildUtils.lua
+++ b/lib/ChildUtils.lua
@@ -39,8 +39,12 @@ ChildUtils.UseParentKey = Symbol.named("UseParentKey")
 function ChildUtils.iterateChildren(childrenOrChild)
 	local richType = Type.of(childrenOrChild)
 
-	-- Single child, the simplest case!
-	if richType ~= nil then
+	if richType == Type.Fragment then
+		return pairs(childrenOrChild.elements)
+	end
+
+	-- Single child
+	if richType == Type.Element then
 		local called = false
 
 		return function()
@@ -54,12 +58,6 @@ function ChildUtils.iterateChildren(childrenOrChild)
 	end
 
 	local regularType = typeof(childrenOrChild)
-
-	-- A dictionary of children, hopefully!
-	-- TODO: Is this too flaky? Should we introduce a Fragment type like React?
-	if regularType == "table" then
-		return pairs(childrenOrChild)
-	end
 
 	if childrenOrChild == nil or regularType == "boolean" then
 		return noop

--- a/lib/ChildUtils.lua
+++ b/lib/ChildUtils.lua
@@ -18,29 +18,29 @@ ChildUtils.UseParentKey = Symbol.named("UseParentKey")
 
 --[[
 	Returns an iterator over the children of an element.
-	`childrenOrChild` may be one of:
+	`elementOrElements` may be one of:
 	* a boolean
 	* nil
 	* a single element
 	* a table of elements
 
-	If `childrenOrChild` is a boolean or nil, this will return an iterator with
+	If `elementOrElements` is a boolean or nil, this will return an iterator with
 	zero elements.
 
-	If `childrenOrChild` is a single element, this will return an iterator with
+	If `elementOrElements` is a single element, this will return an iterator with
 	one element: a tuple where the first value is ChildUtils.UseParentKey, and
-	the second is the value of `childrenOrChild`.
+	the second is the value of `elementOrElements`.
 
-	If `childrenOrChild` is a table, this will return an iterator over all the
-	elements of the array, equivalent to `pairs(childrenOrChild)`.
+	If `elementOrElements` is a table, this will return an iterator over all the
+	elements of the array, equivalent to `pairs(elementOrElements)`.
 
-	If `childrenOrChild` is none of the above, this function will throw.
+	If `elementOrElements` is none of the above, this function will throw.
 ]]
-function ChildUtils.iterateChildren(childrenOrChild)
-	local richType = Type.of(childrenOrChild)
+function ChildUtils.iterateElements(elementOrElements)
+	local richType = Type.of(elementOrElements)
 
 	if richType == Type.Fragment then
-		return pairs(childrenOrChild.elements)
+		return pairs(elementOrElements.elements)
 	end
 
 	-- Single child
@@ -52,14 +52,14 @@ function ChildUtils.iterateChildren(childrenOrChild)
 				return nil
 			else
 				called = true
-				return ChildUtils.UseParentKey, childrenOrChild
+				return ChildUtils.UseParentKey, elementOrElements
 			end
 		end
 	end
 
-	local regularType = typeof(childrenOrChild)
+	local regularType = typeof(elementOrElements)
 
-	if childrenOrChild == nil or regularType == "boolean" then
+	if elementOrElements == nil or regularType == "boolean" then
 		return noop
 	end
 

--- a/lib/ChildUtils.lua
+++ b/lib/ChildUtils.lua
@@ -22,6 +22,7 @@ ChildUtils.UseParentKey = Symbol.named("UseParentKey")
 	* a boolean
 	* nil
 	* a single element
+	* a fragment
 	* a table of elements
 
 	If `elementOrElements` is a boolean or nil, this will return an iterator with
@@ -31,8 +32,8 @@ ChildUtils.UseParentKey = Symbol.named("UseParentKey")
 	one element: a tuple where the first value is ChildUtils.UseParentKey, and
 	the second is the value of `elementOrElements`.
 
-	If `elementOrElements` is a table, this will return an iterator over all the
-	elements of the array, equivalent to `pairs(elementOrElements)`.
+	If `elementOrElements` is a fragment or a table, this will return an iterator
+	over all the elements of the array.
 
 	If `elementOrElements` is none of the above, this function will throw.
 ]]
@@ -58,6 +59,12 @@ function ChildUtils.iterateElements(elementOrElements)
 	end
 
 	local regularType = typeof(elementOrElements)
+
+	-- This is the format we expect for the children of an element
+	-- provided when calling `createElement`
+	if regularType == "table" then
+		return pairs(elementOrElements)
+	end
 
 	if elementOrElements == nil or regularType == "boolean" then
 		return noop

--- a/lib/ChildUtils.spec.lua
+++ b/lib/ChildUtils.spec.lua
@@ -1,6 +1,7 @@
 return function()
 	local ChildUtils = require(script.Parent.ChildUtils)
 	local createElement = require(script.Parent.createElement)
+	local createFragment = require(script.Parent.createFragment)
 	local Type = require(script.Parent.Type)
 
 	describe("iterateElements", function()
@@ -16,11 +17,11 @@ return function()
 			expect(iteratedKey).to.equal(nil)
 		end)
 
-		it("should iterate over multiple children", function()
-			local children = {
+		it("should iterate over fragments", function()
+			local children = createFragment({
 				a = createElement("TextLabel"),
 				b = createElement("TextLabel"),
-			}
+			})
 
 			local seenChildren = {}
 			local count = 0
@@ -33,8 +34,8 @@ return function()
 			end
 
 			expect(count).to.equal(2)
-			expect(seenChildren[children.a]).to.equal("a")
-			expect(seenChildren[children.b]).to.equal("b")
+			expect(seenChildren[children.elements.a]).to.equal("a")
+			expect(seenChildren[children.elements.b]).to.equal("b")
 		end)
 
 		it("should return a zero-element iterator for booleans", function()
@@ -76,17 +77,17 @@ return function()
 		end)
 
 		it("should return the corresponding element", function()
-			local children = {
+			local children = createFragment({
 				a = createElement("TextLabel"),
 				b = createElement("TextLabel"),
-			}
+			})
 
-			expect(ChildUtils.getChildByKey(children, "a")).to.equal(children.a)
-			expect(ChildUtils.getChildByKey(children, "b")).to.equal(children.b)
+			expect(ChildUtils.getChildByKey(children, "a")).to.equal(children.elements.a)
+			expect(ChildUtils.getChildByKey(children, "b")).to.equal(children.elements.b)
 		end)
 
 		it("should return nil if the key does not exist", function()
-			local children = {}
+			local children = createFragment({})
 
 			expect(ChildUtils.getChildByKey(children, "a")).to.equal(nil)
 		end)

--- a/lib/ChildUtils.spec.lua
+++ b/lib/ChildUtils.spec.lua
@@ -3,10 +3,10 @@ return function()
 	local createElement = require(script.Parent.createElement)
 	local Type = require(script.Parent.Type)
 
-	describe("iterateChildren", function()
+	describe("iterateElements", function()
 		it("should iterate once for a single child", function()
 			local child = createElement("TextLabel")
-			local iterator = ChildUtils.iterateChildren(child)
+			local iterator = ChildUtils.iterateElements(child)
 			local iteratedKey, iteratedChild = iterator()
 			-- For single elements, the key should be UseParentKey
 			expect(iteratedKey).to.equal(ChildUtils.UseParentKey)
@@ -25,7 +25,7 @@ return function()
 			local seenChildren = {}
 			local count = 0
 
-			for key, child in ChildUtils.iterateChildren(children) do
+			for key, child in ChildUtils.iterateElements(children) do
 				expect(typeof(key)).to.equal("string")
 				expect(Type.of(child)).to.equal(Type.Element)
 				seenChildren[child] = key
@@ -38,18 +38,18 @@ return function()
 		end)
 
 		it("should return a zero-element iterator for booleans", function()
-			local booleanIterator = ChildUtils.iterateChildren(false)
+			local booleanIterator = ChildUtils.iterateElements(false)
 			expect(booleanIterator()).to.equal(nil)
 		end)
 
 		it("should return a zero-element iterator for nil", function()
-			local nilIterator = ChildUtils.iterateChildren(nil)
+			local nilIterator = ChildUtils.iterateElements(nil)
 			expect(nilIterator()).to.equal(nil)
 		end)
 
 		it("should throw if given an illegal value", function()
 			expect(function()
-				ChildUtils.iterateChildren(1)
+				ChildUtils.iterateElements(1)
 			end).to.throw()
 		end)
 	end)

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -188,7 +188,7 @@ function Component:__mount(reconciler, virtualNode)
 	local children = instance:render()
 	internalData.setStateBlockedReason = nil
 
-	reconciler.updateVirtualNodeChildren(virtualNode, hostParent, children)
+	reconciler.updateVirtualNodeWithElements(virtualNode, hostParent, children)
 
 	if instance.didMount ~= nil then
 		instance:didMount()
@@ -289,7 +289,7 @@ function Component:__update(updatedElement, updatedState)
 	local renderResult = virtualNode.instance:render()
 	internalData.setStateBlockedReason = nil
 
-	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostParent, renderResult)
+	reconciler.updateVirtualNodeWithElements(virtualNode, virtualNode.hostParent, renderResult)
 
 	if self.didUpdate ~= nil then
 		self:didUpdate(oldProps, oldState)

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -188,7 +188,7 @@ function Component:__mount(reconciler, virtualNode)
 	local children = instance:render()
 	internalData.setStateBlockedReason = nil
 
-	reconciler.updateVirtualNodeWithElements(virtualNode, hostParent, children)
+	reconciler.updateVirtualNodeChildrenFromElements(virtualNode, hostParent, children)
 
 	if instance.didMount ~= nil then
 		instance:didMount()
@@ -289,7 +289,7 @@ function Component:__update(updatedElement, updatedState)
 	local renderResult = virtualNode.instance:render()
 	internalData.setStateBlockedReason = nil
 
-	reconciler.updateVirtualNodeWithElements(virtualNode, virtualNode.hostParent, renderResult)
+	reconciler.updateVirtualNodeChildrenFromElements(virtualNode, virtualNode.hostParent, renderResult)
 
 	if self.didUpdate ~= nil then
 		self:didUpdate(oldProps, oldState)

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -185,10 +185,10 @@ function Component:__mount(reconciler, virtualNode)
 	virtualNode.context = instance._context
 
 	internalData.setStateBlockedReason = "render"
-	local children = instance:render()
+	local renderResult = instance:render()
 	internalData.setStateBlockedReason = nil
 
-	reconciler.updateVirtualNodeChildrenFromElements(virtualNode, hostParent, children)
+	reconciler.updateVirtualNodeWithRenderResult(virtualNode, hostParent, renderResult)
 
 	if instance.didMount ~= nil then
 		instance:didMount()
@@ -289,7 +289,7 @@ function Component:__update(updatedElement, updatedState)
 	local renderResult = virtualNode.instance:render()
 	internalData.setStateBlockedReason = nil
 
-	reconciler.updateVirtualNodeChildrenFromElements(virtualNode, virtualNode.hostParent, renderResult)
+	reconciler.updateVirtualNodeWithRenderResult(virtualNode, virtualNode.hostParent, renderResult)
 
 	if self.didUpdate ~= nil then
 		self:didUpdate(oldProps, oldState)

--- a/lib/ElementUtils.lua
+++ b/lib/ElementUtils.lua
@@ -64,7 +64,11 @@ function ElementUtils.iterateElements(elementOrElements)
 		return noop
 	end
 
-	error("Invalid children")
+	if regularType == "table" then
+		return pairs(elementOrElements)
+	end
+
+	error("Invalid elements")
 end
 
 --[[
@@ -91,6 +95,10 @@ function ElementUtils.getElementByKey(elements, hostKey)
 
 	if Type.of(elements) == Type.Fragment then
 		return elements.elements[hostKey]
+	end
+
+	if typeof(elements) == "table" then
+		return elements[hostKey]
 	end
 
 	error("Invalid elements")

--- a/lib/ElementUtils.lua
+++ b/lib/ElementUtils.lua
@@ -5,7 +5,7 @@ local function noop()
 	return nil
 end
 
-local ChildUtils = {}
+local ElementUtils = {}
 
 --[[
 	A signal value indicating that a child should use its parent's key, because
@@ -14,7 +14,7 @@ local ChildUtils = {}
 	This occurs when you return only one element from a function component or
 	stateful render function.
 ]]
-ChildUtils.UseParentKey = Symbol.named("UseParentKey")
+ElementUtils.UseParentKey = Symbol.named("UseParentKey")
 
 --[[
 	Returns an iterator over the children of an element.
@@ -29,7 +29,7 @@ ChildUtils.UseParentKey = Symbol.named("UseParentKey")
 	zero elements.
 
 	If `elementOrElements` is a single element, this will return an iterator with
-	one element: a tuple where the first value is ChildUtils.UseParentKey, and
+	one element: a tuple where the first value is ElementUtils.UseParentKey, and
 	the second is the value of `elementOrElements`.
 
 	If `elementOrElements` is a fragment or a table, this will return an iterator
@@ -37,7 +37,7 @@ ChildUtils.UseParentKey = Symbol.named("UseParentKey")
 
 	If `elementOrElements` is none of the above, this function will throw.
 ]]
-function ChildUtils.iterateElements(elementOrElements)
+function ElementUtils.iterateElements(elementOrElements)
 	local richType = Type.of(elementOrElements)
 
 	if richType == Type.Fragment then
@@ -53,7 +53,7 @@ function ChildUtils.iterateElements(elementOrElements)
 				return nil
 			else
 				called = true
-				return ChildUtils.UseParentKey, elementOrElements
+				return ElementUtils.UseParentKey, elementOrElements
 			end
 		end
 	end
@@ -79,16 +79,16 @@ end
 	* If `elements` is nil or a boolean, this will return `nil`, regardless of
 		the key given.
 	* If `elements` is a single element, this will return `nil`, unless the key
-		is ChildUtils.UseParentKey.
+		is ElementUtils.UseParentKey.
 	* If `elements` is a table of elements, this will return `elements[key]`.
 ]]
-function ChildUtils.getChildByKey(elements, hostKey)
+function ElementUtils.getElementByKey(elements, hostKey)
 	if elements == nil or typeof(elements) == "boolean" then
 		return nil
 	end
 
 	if Type.of(elements) == Type.Element then
-		if hostKey == ChildUtils.UseParentKey then
+		if hostKey == ElementUtils.UseParentKey then
 			return elements
 		end
 
@@ -104,4 +104,4 @@ function ChildUtils.getChildByKey(elements, hostKey)
 	-- return elements[hostKey]
 end
 
-return ChildUtils
+return ElementUtils

--- a/lib/ElementUtils.lua
+++ b/lib/ElementUtils.lua
@@ -60,12 +60,6 @@ function ElementUtils.iterateElements(elementOrElements)
 
 	local regularType = typeof(elementOrElements)
 
-	-- This is the format we expect for the children of an element
-	-- provided when calling `createElement`
-	if regularType == "table" then
-		return pairs(elementOrElements)
-	end
-
 	if elementOrElements == nil or regularType == "boolean" then
 		return noop
 	end
@@ -100,8 +94,6 @@ function ElementUtils.getElementByKey(elements, hostKey)
 	end
 
 	error("Invalid elements")
-	-- TODO: Let's fix this case; it should work for fragments(?), but not arbitrary tables
-	-- return elements[hostKey]
 end
 
 return ElementUtils

--- a/lib/ElementUtils.spec.lua
+++ b/lib/ElementUtils.spec.lua
@@ -1,5 +1,5 @@
 return function()
-	local ChildUtils = require(script.Parent.ChildUtils)
+	local ElementUtils = require(script.Parent.ElementUtils)
 	local createElement = require(script.Parent.createElement)
 	local createFragment = require(script.Parent.createFragment)
 	local Type = require(script.Parent.Type)
@@ -7,10 +7,10 @@ return function()
 	describe("iterateElements", function()
 		it("should iterate once for a single child", function()
 			local child = createElement("TextLabel")
-			local iterator = ChildUtils.iterateElements(child)
+			local iterator = ElementUtils.iterateElements(child)
 			local iteratedKey, iteratedChild = iterator()
 			-- For single elements, the key should be UseParentKey
-			expect(iteratedKey).to.equal(ChildUtils.UseParentKey)
+			expect(iteratedKey).to.equal(ElementUtils.UseParentKey)
 			expect(iteratedChild).to.equal(child)
 
 			iteratedKey = iterator()
@@ -26,7 +26,7 @@ return function()
 			local seenChildren = {}
 			local count = 0
 
-			for key, child in ChildUtils.iterateElements(children) do
+			for key, child in ElementUtils.iterateElements(children) do
 				expect(typeof(key)).to.equal("string")
 				expect(Type.of(child)).to.equal(Type.Element)
 				seenChildren[child] = key
@@ -39,40 +39,40 @@ return function()
 		end)
 
 		it("should return a zero-element iterator for booleans", function()
-			local booleanIterator = ChildUtils.iterateElements(false)
+			local booleanIterator = ElementUtils.iterateElements(false)
 			expect(booleanIterator()).to.equal(nil)
 		end)
 
 		it("should return a zero-element iterator for nil", function()
-			local nilIterator = ChildUtils.iterateElements(nil)
+			local nilIterator = ElementUtils.iterateElements(nil)
 			expect(nilIterator()).to.equal(nil)
 		end)
 
 		it("should throw if given an illegal value", function()
 			expect(function()
-				ChildUtils.iterateElements(1)
+				ElementUtils.iterateElements(1)
 			end).to.throw()
 		end)
 	end)
 
-	describe("getChildByKey", function()
+	describe("getElementByKey", function()
 		it("should return nil for booleans", function()
-			expect(ChildUtils.getChildByKey(true, "test")).to.equal(nil)
+			expect(ElementUtils.getElementByKey(true, "test")).to.equal(nil)
 		end)
 
 		it("should return nil for nil", function()
-			expect(ChildUtils.getChildByKey(nil, "test")).to.equal(nil)
+			expect(ElementUtils.getElementByKey(nil, "test")).to.equal(nil)
 		end)
 
 		describe("single elements", function()
 			local element = createElement("TextLabel")
 
 			it("should return the element if the key is UseParentKey", function()
-				expect(ChildUtils.getChildByKey(element, ChildUtils.UseParentKey)).to.equal(element)
+				expect(ElementUtils.getElementByKey(element, ElementUtils.UseParentKey)).to.equal(element)
 			end)
 
 			it("should return nil if the key is not UseParentKey", function()
-				expect(ChildUtils.getChildByKey(element, "test")).to.equal(nil)
+				expect(ElementUtils.getElementByKey(element, "test")).to.equal(nil)
 			end)
 		end)
 
@@ -82,14 +82,14 @@ return function()
 				b = createElement("TextLabel"),
 			})
 
-			expect(ChildUtils.getChildByKey(children, "a")).to.equal(children.elements.a)
-			expect(ChildUtils.getChildByKey(children, "b")).to.equal(children.elements.b)
+			expect(ElementUtils.getElementByKey(children, "a")).to.equal(children.elements.a)
+			expect(ElementUtils.getElementByKey(children, "b")).to.equal(children.elements.b)
 		end)
 
 		it("should return nil if the key does not exist", function()
 			local children = createFragment({})
 
-			expect(ChildUtils.getChildByKey(children, "a")).to.equal(nil)
+			expect(ElementUtils.getElementByKey(children, "a")).to.equal(nil)
 		end)
 	end)
 end

--- a/lib/ElementUtils.spec.lua
+++ b/lib/ElementUtils.spec.lua
@@ -38,6 +38,27 @@ return function()
 			expect(seenChildren[children.elements.b]).to.equal("b")
 		end)
 
+		it("should iterate over tables", function()
+			local children = {
+				a = createElement("TextLabel"),
+				b = createElement("TextLabel"),
+			}
+
+			local seenChildren = {}
+			local count = 0
+
+			for key, child in ElementUtils.iterateElements(children) do
+				expect(typeof(key)).to.equal("string")
+				expect(Type.of(child)).to.equal(Type.Element)
+				seenChildren[child] = key
+				count = count + 1
+			end
+
+			expect(count).to.equal(2)
+			expect(seenChildren[children.a]).to.equal("a")
+			expect(seenChildren[children.b]).to.equal("b")
+		end)
+
 		it("should return a zero-element iterator for booleans", function()
 			local booleanIterator = ElementUtils.iterateElements(false)
 			expect(booleanIterator()).to.equal(nil)
@@ -76,7 +97,7 @@ return function()
 			end)
 		end)
 
-		it("should return the corresponding element", function()
+		it("should return the corresponding element from a fragment", function()
 			local children = createFragment({
 				a = createElement("TextLabel"),
 				b = createElement("TextLabel"),
@@ -84,6 +105,16 @@ return function()
 
 			expect(ElementUtils.getElementByKey(children, "a")).to.equal(children.elements.a)
 			expect(ElementUtils.getElementByKey(children, "b")).to.equal(children.elements.b)
+		end)
+
+		it("should return the corresponding element from a table", function()
+			local children = {
+				a = createElement("TextLabel"),
+				b = createElement("TextLabel"),
+			}
+
+			expect(ElementUtils.getElementByKey(children, "a")).to.equal(children.a)
+			expect(ElementUtils.getElementByKey(children, "b")).to.equal(children.b)
 		end)
 
 		it("should return nil if the key does not exist", function()

--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -141,6 +141,7 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 
 	local children = element.props[Children]
 
+	-- FIXME: Calling updateVirtualNodeChildren with a 'children' value that is not a render result
 	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, children)
 
 	instance.Parent = hostParent
@@ -199,6 +200,7 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 		end
 	end
 
+	-- FIXME: Calling updateVirtualNodeChildren with a 'children' value that is not a render result
 	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
 
 	-- Resume event firing now that everything's updated successfully

--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -141,7 +141,7 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 
 	local children = element.props[Children]
 
-	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, children)
+	reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
 
 	instance.Parent = hostParent
 	virtualNode.hostObject = instance
@@ -199,7 +199,7 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 		end
 	end
 
-	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
+	reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
 
 	-- Resume event firing now that everything's updated successfully
 	if virtualNode.eventManager ~= nil then

--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -141,7 +141,6 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 
 	local children = element.props[Children]
 
-	-- FIXME: Calling updateVirtualNodeChildren with a 'children' value that is not a render result
 	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, children)
 
 	instance.Parent = hostParent
@@ -200,7 +199,6 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 		end
 	end
 
-	-- FIXME: Calling updateVirtualNodeChildren with a 'children' value that is not a render result
 	reconciler.updateVirtualNodeChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
 
 	-- Resume event firing now that everything's updated successfully

--- a/lib/Type.lua
+++ b/lib/Type.lua
@@ -20,10 +20,11 @@ local function addType(name)
 	TypeInternal[name] = Symbol.named("Roact" .. name)
 end
 
+addType("Binding")
 addType("Element")
+addType("Fragment")
 addType("HostChangeEvent")
 addType("HostEvent")
-addType("Binding")
 addType("StatefulComponentClass")
 addType("StatefulComponentInstance")
 addType("VirtualNode")

--- a/lib/createFragment.lua
+++ b/lib/createFragment.lua
@@ -1,0 +1,10 @@
+local Type = require(script.Parent.Type)
+
+local function createFragment(elements)
+	return {
+		[Type] = Type.Fragment,
+		elements = elements,
+	}
+end
+
+return createFragment

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -49,7 +49,7 @@ local function createReconciler(renderer)
 		Utility to update the children of a virtual node based on zero or more
 		updated children given as elements.
 	]]
-	local function updateVirtualNodeChildren(virtualNode, hostParent, newChildElements)
+	local function updateChildren(virtualNode, hostParent, newChildElements)
 		assert(Type.of(virtualNode) == Type.VirtualNode)
 
 		local removeKeys = {}
@@ -89,13 +89,17 @@ local function createReconciler(renderer)
 		end
 	end
 
+	local function updateVirtualNodeWithChildren(virtualNode, hostParent, newChildElements)
+		updateChildren(virtualNode, hostParent, newChildElements)
+	end
+
 	local function updateVirtualNodeWithRenderResult(virtualNode, hostParent, renderResult)
 		if renderResult == nil
 			or typeof(renderResult) == "boolean"
 			or Type.of(renderResult) == Type.Element
 			or Type.of(renderResult) == Type.Fragment
 		then
-			updateVirtualNodeChildren(virtualNode, hostParent, renderResult)
+			updateChildren(virtualNode, hostParent, renderResult)
 		else
 			-- TODO: Better error message
 			Logging.error(("%s\n%s"):format(
@@ -156,7 +160,7 @@ local function createReconciler(renderer)
 
 		local children = newElement.props[Children]
 
-		updateVirtualNodeChildren(virtualNode, targetHostParent, children)
+		updateVirtualNodeWithChildren(virtualNode, targetHostParent, children)
 
 		return virtualNode
 	end
@@ -264,7 +268,7 @@ local function createReconciler(renderer)
 
 		assert(renderer.isHostObject(targetHostParent))
 
-		updateVirtualNodeChildren(virtualNode, targetHostParent, children)
+		updateVirtualNodeWithChildren(virtualNode, targetHostParent, children)
 	end
 
 	--[[
@@ -369,7 +373,7 @@ local function createReconciler(renderer)
 		mountVirtualNode = mountVirtualNode,
 		unmountVirtualNode = unmountVirtualNode,
 		updateVirtualNode = updateVirtualNode,
-		updateVirtualNodeChildren = updateVirtualNodeChildren,
+		updateVirtualNodeWithChildren = updateVirtualNodeWithChildren,
 		updateVirtualNodeWithRenderResult = updateVirtualNodeWithRenderResult,
 	}
 

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -98,7 +98,10 @@ local function createReconciler(renderer)
 			updateVirtualNodeChildren(virtualNode, hostParent, newChildElements)
 		else
 			-- TODO: Better error message
-			error(("%s\n%s"):format("Component returned invalid children:", virtualNode.currentElement.source), 0)
+			error(("%s\n%s"):format(
+				"Component returned invalid children:",
+				virtualNode.currentElement.source or ""
+			), 0)
 		end
 	end
 

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -71,7 +71,7 @@ local function createReconciler(renderer)
 		end
 
 		-- Added children
-		for childKey, newElement in ChildUtils.iterateChildren(newChildElements) do
+		for childKey, newElement in ChildUtils.iterateElements(newChildElements) do
 			local concreteKey = childKey
 			if childKey == ChildUtils.UseParentKey then
 				concreteKey = virtualNode.hostKey

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -98,7 +98,7 @@ local function createReconciler(renderer)
 			updateVirtualNodeChildren(virtualNode, hostParent, newChildElements)
 		else
 			-- TODO: Better error message
-			error(("%s\n%s"):format(
+			Logging.error(("%s\n%s"):format(
 				"Component returned invalid children:",
 				virtualNode.currentElement.source or ""
 			), 0)

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -89,13 +89,13 @@ local function createReconciler(renderer)
 		end
 	end
 
-	local function updateVirtualNodeChildrenFromElements(virtualNode, hostParent, newChildElements)
-		if newChildElements == nil
-			or typeof(newChildElements) == "boolean"
-			or Type.of(newChildElements) == Type.Element
-			or Type.of(newChildElements) == Type.Fragment
+	local function updateVirtualNodeWithRenderResult(virtualNode, hostParent, renderResult)
+		if renderResult == nil
+			or typeof(renderResult) == "boolean"
+			or Type.of(renderResult) == Type.Element
+			or Type.of(renderResult) == Type.Fragment
 		then
-			updateVirtualNodeChildren(virtualNode, hostParent, newChildElements)
+			updateVirtualNodeChildren(virtualNode, hostParent, renderResult)
 		else
 			-- TODO: Better error message
 			Logging.error(("%s\n%s"):format(
@@ -133,7 +133,7 @@ local function createReconciler(renderer)
 	local function updateFunctionVirtualNode(virtualNode, newElement)
 		local children = newElement.component(newElement.props)
 
-		updateVirtualNodeChildrenFromElements(virtualNode, virtualNode.hostParent, children)
+		updateVirtualNodeWithRenderResult(virtualNode, virtualNode.hostParent, children)
 
 		return virtualNode
 	end
@@ -253,7 +253,7 @@ local function createReconciler(renderer)
 
 		local children = element.component(element.props)
 
-		updateVirtualNodeChildrenFromElements(virtualNode, virtualNode.hostParent, children)
+		updateVirtualNodeWithRenderResult(virtualNode, virtualNode.hostParent, children)
 	end
 
 	local function mountPortalVirtualNode(virtualNode)
@@ -370,7 +370,7 @@ local function createReconciler(renderer)
 		unmountVirtualNode = unmountVirtualNode,
 		updateVirtualNode = updateVirtualNode,
 		updateVirtualNodeChildren = updateVirtualNodeChildren,
-		updateVirtualNodeChildrenFromElements = updateVirtualNodeChildrenFromElements,
+		updateVirtualNodeWithRenderResult = updateVirtualNodeWithRenderResult,
 	}
 
 	return reconciler

--- a/lib/createReconciler.spec.lua
+++ b/lib/createReconciler.spec.lua
@@ -50,8 +50,8 @@ return function()
 		end)
 	end)
 
-	describe("elements", function()
-		it("should throw errors when attempting to mount invalid element values", function()
+	describe("elements and fragments", function()
+		it("should throw errors when attempting to mount invalid elements", function()
 			-- These function components return values with incorrect types
 			local returnsString = function()
 				return "Hello"

--- a/lib/createReconciler.spec.lua
+++ b/lib/createReconciler.spec.lua
@@ -52,28 +52,37 @@ return function()
 
 	describe("elements", function()
 		it("should throw errors when attempting to mount invalid element values", function()
-			local stringElement = "Hello"
-			local numberElement = 1
-			local functionElement = function() end
-			local tableElement = {}
+			-- These function components return values with incorrect types
+			local returnsString = function()
+				return "Hello"
+			end
+			local returnsNumber = function()
+				return 1
+			end
+			local returnsFunction = function()
+				return function() end
+			end
+			local returnsTable = function()
+				return {}
+			end
 
 			local hostParent = nil
 			local key = "Some Key"
 
 			expect(function()
-				noopReconciler.mountVirtualNode(stringElement, hostParent, key)
+				noopReconciler.mountVirtualNode(createElement(returnsString), hostParent, key)
 			end).to.throw()
 
 			expect(function()
-				noopReconciler.mountVirtualNode(numberElement, hostParent, key)
+				noopReconciler.mountVirtualNode(createElement(returnsNumber), hostParent, key)
 			end).to.throw()
 
 			expect(function()
-				noopReconciler.mountVirtualNode(functionElement, hostParent, key)
+				noopReconciler.mountVirtualNode(createElement(returnsFunction), hostParent, key)
 			end).to.throw()
 
 			expect(function()
-				noopReconciler.mountVirtualNode(tableElement, hostParent, key)
+				noopReconciler.mountVirtualNode(createElement(returnsTable), hostParent, key)
 			end).to.throw()
 		end)
 	end)

--- a/lib/createReconciler.spec.lua
+++ b/lib/createReconciler.spec.lua
@@ -1,6 +1,7 @@
 return function()
 	local assign = require(script.Parent.assign)
 	local createElement = require(script.Parent.createElement)
+	local createFragment = require(script.Parent.createFragment)
 	local createSpy = require(script.Parent.createSpy)
 	local NoopRenderer = require(script.Parent.NoopRenderer)
 	local Type = require(script.Parent.Type)
@@ -198,7 +199,7 @@ return function()
 			expect(childComponentSpy.callCount).to.equal(1)
 		end)
 
-		it("should mount multiple children of function components", function()
+		it("should mount fragments returned by function components", function()
 			local childAComponentSpy = createSpy(function(props)
 				return nil
 			end)
@@ -208,14 +209,14 @@ return function()
 			end)
 
 			local parentComponentSpy = createSpy(function(props)
-				return {
+				return createFragment({
 					A = createElement(childAComponentSpy.value, {
 						value = props.value + 1,
 					}),
 					B = createElement(childBComponentSpy.value, {
 						value = props.value + 5,
 					}),
-				}
+				})
 			end)
 
 			local element = createElement(parentComponentSpy.value, {

--- a/lib/createReconciler.spec.lua
+++ b/lib/createReconciler.spec.lua
@@ -50,6 +50,34 @@ return function()
 		end)
 	end)
 
+	describe("elements", function()
+		it("should throw errors when attempting to mount invalid element values", function()
+			local stringElement = "Hello"
+			local numberElement = 1
+			local functionElement = function() end
+			local tableElement = {}
+
+			local hostParent = nil
+			local key = "Some Key"
+
+			expect(function()
+				noopReconciler.mountVirtualNode(stringElement, hostParent, key)
+			end).to.throw()
+
+			expect(function()
+				noopReconciler.mountVirtualNode(numberElement, hostParent, key)
+			end).to.throw()
+
+			expect(function()
+				noopReconciler.mountVirtualNode(functionElement, hostParent, key)
+			end).to.throw()
+
+			expect(function()
+				noopReconciler.mountVirtualNode(tableElement, hostParent, key)
+			end).to.throw()
+		end)
+	end)
+
 	describe("Host components", function()
 		it("should invoke the renderer to mount host nodes", function()
 			local mountHostNode = createSpy(NoopRenderer.mountHostNode)


### PR DESCRIPTION
Closes #7 (for the new reconciler).

I started from the `new-reconciler-fragments` branch that @LPGhatguy made and finished repairing/adding tests and patching inconsistencies.

One thing that fell out of this change was the need to distinguish between these two scenarios:
1. Updating a virtual node's children from a list of new children
   1. This is done by the `RobloxRenderer` to process the children of host nodes, and also the reconciler itself to process children specified via `Roact.Children`.
   2. The children are expected to be in the form of a table.
2. Updating a virtual node's children with the result of rendering a component.
   1. This is done by `Component` with its lifecycle methods, and also by the reconciler itself to mount/update function components.
   2. The expected format is either an element or a fragment (or a boolean value or nil).

Right now, I'm enforcing the above rules with two different reconciler functions for updating a node's children.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation