### PR TITLE
validateProps for new reconciler

### DIFF
--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -186,11 +186,12 @@ function Component:__mount(reconciler, virtualNode)
 	virtualNode.instance = instance
 
 	local props = currentElement.props
-	instance:__validateProps(props)
 
 	if self.defaultProps ~= nil then
 		props = assign({}, self.defaultProps, props)
 	end
+
+	instance:__validateProps(props)
 
 	instance.props = props
 	instance.state = {}
@@ -279,11 +280,12 @@ function Component:__update(updatedElement, updatedState)
 
 	if updatedElement ~= nil then
 		newProps = updatedElement.props
-		self:__validateProps(newProps)
 
 		if componentClass.defaultProps ~= nil then
 			newProps = assign({}, componentClass.defaultProps, newProps)
 		end
+
+		self:__validateProps(newProps)
 	end
 
 	if updatedState ~= nil then

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -2,6 +2,7 @@ local assign = require(script.Parent.assign)
 local Type = require(script.Parent.Type)
 local Symbol = require(script.Parent.Symbol)
 local invalidSetStateMessages = require(script.Parent.invalidSetStateMessages)
+local GlobalConfig = require(script.Parent.GlobalConfig)
 
 local InternalData = Symbol.named("InternalData")
 
@@ -129,6 +130,10 @@ end
 	error.
 ]]
 function Component:__validateProps(props)
+	if not GlobalConfig.getValue("propertyValidation") then
+		return
+	end
+
 	local validator = self[InternalData].componentClass.validateProps
 
 	if validator == nil then

--- a/lib/Component.spec/validateProps.spec.lua
+++ b/lib/Component.spec/validateProps.spec.lua
@@ -1,0 +1,135 @@
+return function()
+    local createElement = require(script.Parent.Parent.createElement)
+    local createReconciler = require(script.Parent.Parent.createReconciler)
+    local createSpy = require(script.Parent.Parent.createSpy)
+    local NoopRenderer = require(script.Parent.Parent.NoopRenderer)
+
+    local Component = require(script.Parent.Parent.Component)
+
+    local noopReconciler = createReconciler(NoopRenderer)
+
+    it("should be invoked when mounted", function()
+        local MyComponent = Component:extend("MyComponent")
+
+        local validatePropsSpy = createSpy(function()
+            return true
+        end)
+
+        MyComponent.validateProps = validatePropsSpy.value
+
+        function MyComponent:render()
+            return nil
+        end
+
+        local element = createElement(MyComponent)
+		local hostParent = nil
+        local key = "Test"
+
+        noopReconciler.mountVirtualNode(element, hostParent, key)
+        expect(validatePropsSpy.callCount).to.equal(1)
+    end)
+
+    it("should be invoked when props change", function()
+        local MyComponent = Component:extend("MyComponent")
+
+        local validatePropsSpy = createSpy(function()
+            return true
+        end)
+
+        MyComponent.validateProps = validatePropsSpy.value
+
+        function MyComponent:render()
+            return nil
+        end
+
+        local element = createElement(MyComponent, { a = 1 })
+		local hostParent = nil
+        local key = "Test"
+
+        local node = noopReconciler.mountVirtualNode(element, hostParent, key)
+        local values = validatePropsSpy:captureValues("props")
+        expect(validatePropsSpy.callCount).to.equal(1)
+        expect(values.props).to.be.ok()
+        expect(values.props.a).to.equal(1)
+
+        local newElement = createElement(MyComponent, { a = 2 })
+        noopReconciler.updateVirtualNode(node, newElement)
+        values = validatePropsSpy:captureValues("props")
+        expect(validatePropsSpy.callCount).to.equal(2)
+        expect(values.props).to.be.ok()
+        expect(values.props.a).to.equal(2)
+    end)
+
+    it("should not be invoked when state changes", function()
+        local MyComponent = Component:extend("MyComponent")
+
+        local setStateCallback = nil
+        local validatePropsSpy = createSpy(function()
+            return true
+        end)
+
+        MyComponent.validateProps = validatePropsSpy.value
+
+        function MyComponent:init()
+            setStateCallback = function(newState)
+                self:setState(newState)
+            end
+        end
+
+        function MyComponent:render()
+            return nil
+        end
+
+        local element = createElement(MyComponent, { a = 1 })
+		local hostParent = nil
+        local key = "Test"
+
+        noopReconciler.mountVirtualNode(element, hostParent, key)
+        local values = validatePropsSpy:captureValues("props")
+        expect(validatePropsSpy.callCount).to.equal(1)
+        expect(values.props).to.be.ok()
+        expect(values.props.a).to.equal(1)
+
+        setStateCallback({
+            b = 1
+        })
+
+        expect(validatePropsSpy.callCount).to.equal(1)
+    end)
+
+    it("should throw if validateProps is not a function", function()
+        local MyComponent = Component:extend("MyComponent")
+        MyComponent.validateProps = 1
+
+        function MyComponent:render()
+            return nil
+        end
+
+        local element = createElement(MyComponent)
+		local hostParent = nil
+        local key = "Test"
+
+        expect(function()
+            noopReconciler.mountVirtualNode(element, hostParent, key)
+        end).to.throw()
+    end)
+
+    it("should throw if validateProps returns false", function()
+        local MyComponent = Component:extend("MyComponent")
+        MyComponent.validateProps = function()
+            return false
+        end
+
+        function MyComponent:render()
+            return nil
+        end
+
+        local element = createElement(MyComponent)
+		local hostParent = nil
+        local key = "Test"
+
+        expect(function()
+            noopReconciler.mountVirtualNode(element, hostParent, key)
+        end).to.throw()
+    end)
+end

--- a/lib/Component.spec/validateProps.spec.lua
+++ b/lib/Component.spec/validateProps.spec.lua
@@ -47,17 +47,17 @@ return function()
         local key = "Test"
 
         local node = noopReconciler.mountVirtualNode(element, hostParent, key)
-        local values = validatePropsSpy:captureValues("props")
         expect(validatePropsSpy.callCount).to.equal(1)
-        expect(values.props).to.be.ok()
-        expect(values.props.a).to.equal(1)
+        validatePropsSpy:assertCalledWithDeepEqual({
+            a = 1,
+        })
 
         local newElement = createElement(MyComponent, { a = 2 })
         noopReconciler.updateVirtualNode(node, newElement)
-        values = validatePropsSpy:captureValues("props")
         expect(validatePropsSpy.callCount).to.equal(2)
-        expect(values.props).to.be.ok()
-        expect(values.props.a).to.equal(2)
+        validatePropsSpy:assertCalledWithDeepEqual({
+            a = 2,
+        })
     end)
 
     it("should not be invoked when state changes", function()
@@ -85,10 +85,10 @@ return function()
         local key = "Test"
 
         noopReconciler.mountVirtualNode(element, hostParent, key)
-        local values = validatePropsSpy:captureValues("props")
         expect(validatePropsSpy.callCount).to.equal(1)
-        expect(values.props).to.be.ok()
-        expect(values.props.a).to.equal(1)
+        validatePropsSpy:assertCalledWithDeepEqual({
+            a = 1
+        })
 
         setStateCallback({
             b = 1

--- a/lib/Component.spec/validateProps.spec.lua
+++ b/lib/Component.spec/validateProps.spec.lua
@@ -1,172 +1,172 @@
 return function()
-    local createElement = require(script.Parent.Parent.createElement)
-    local createReconciler = require(script.Parent.Parent.createReconciler)
-    local createSpy = require(script.Parent.Parent.createSpy)
-    local NoopRenderer = require(script.Parent.Parent.NoopRenderer)
+	local createElement = require(script.Parent.Parent.createElement)
+	local createReconciler = require(script.Parent.Parent.createReconciler)
+	local createSpy = require(script.Parent.Parent.createSpy)
+	local NoopRenderer = require(script.Parent.Parent.NoopRenderer)
 
-    local Component = require(script.Parent.Parent.Component)
+	local Component = require(script.Parent.Parent.Component)
 
-    local noopReconciler = createReconciler(NoopRenderer)
+	local noopReconciler = createReconciler(NoopRenderer)
 
-    it("should be invoked when mounted", function()
-        local MyComponent = Component:extend("MyComponent")
+	it("should be invoked when mounted", function()
+		local MyComponent = Component:extend("MyComponent")
 
-        local validatePropsSpy = createSpy(function()
-            return true
-        end)
+		local validatePropsSpy = createSpy(function()
+			return true
+		end)
 
-        MyComponent.validateProps = validatePropsSpy.value
+		MyComponent.validateProps = validatePropsSpy.value
 
-        function MyComponent:render()
-            return nil
-        end
+		function MyComponent:render()
+			return nil
+		end
 
-        local element = createElement(MyComponent)
+		local element = createElement(MyComponent)
 		local hostParent = nil
-        local key = "Test"
+		local key = "Test"
 
-        noopReconciler.mountVirtualNode(element, hostParent, key)
-        expect(validatePropsSpy.callCount).to.equal(1)
-    end)
+		noopReconciler.mountVirtualNode(element, hostParent, key)
+		expect(validatePropsSpy.callCount).to.equal(1)
+	end)
 
-    it("should be invoked when props change", function()
-        local MyComponent = Component:extend("MyComponent")
+	it("should be invoked when props change", function()
+		local MyComponent = Component:extend("MyComponent")
 
-        local validatePropsSpy = createSpy(function()
-            return true
-        end)
+		local validatePropsSpy = createSpy(function()
+			return true
+		end)
 
-        MyComponent.validateProps = validatePropsSpy.value
+		MyComponent.validateProps = validatePropsSpy.value
 
-        function MyComponent:render()
-            return nil
-        end
+		function MyComponent:render()
+			return nil
+		end
 
-        local element = createElement(MyComponent, { a = 1 })
+		local element = createElement(MyComponent, { a = 1 })
 		local hostParent = nil
-        local key = "Test"
+		local key = "Test"
 
-        local node = noopReconciler.mountVirtualNode(element, hostParent, key)
-        expect(validatePropsSpy.callCount).to.equal(1)
-        validatePropsSpy:assertCalledWithDeepEqual({
-            a = 1,
-        })
+		local node = noopReconciler.mountVirtualNode(element, hostParent, key)
+		expect(validatePropsSpy.callCount).to.equal(1)
+		validatePropsSpy:assertCalledWithDeepEqual({
+			a = 1,
+		})
 
-        local newElement = createElement(MyComponent, { a = 2 })
-        noopReconciler.updateVirtualNode(node, newElement)
-        expect(validatePropsSpy.callCount).to.equal(2)
-        validatePropsSpy:assertCalledWithDeepEqual({
-            a = 2,
-        })
-    end)
+		local newElement = createElement(MyComponent, { a = 2 })
+		noopReconciler.updateVirtualNode(node, newElement)
+		expect(validatePropsSpy.callCount).to.equal(2)
+		validatePropsSpy:assertCalledWithDeepEqual({
+			a = 2,
+		})
+	end)
 
-    it("should not be invoked when state changes", function()
-        local MyComponent = Component:extend("MyComponent")
+	it("should not be invoked when state changes", function()
+		local MyComponent = Component:extend("MyComponent")
 
-        local setStateCallback = nil
-        local validatePropsSpy = createSpy(function()
-            return true
-        end)
+		local setStateCallback = nil
+		local validatePropsSpy = createSpy(function()
+			return true
+		end)
 
-        MyComponent.validateProps = validatePropsSpy.value
+		MyComponent.validateProps = validatePropsSpy.value
 
-        function MyComponent:init()
-            setStateCallback = function(newState)
-                self:setState(newState)
-            end
-        end
+		function MyComponent:init()
+			setStateCallback = function(newState)
+				self:setState(newState)
+			end
+		end
 
-        function MyComponent:render()
-            return nil
-        end
+		function MyComponent:render()
+			return nil
+		end
 
-        local element = createElement(MyComponent, { a = 1 })
+		local element = createElement(MyComponent, { a = 1 })
 		local hostParent = nil
-        local key = "Test"
+		local key = "Test"
 
-        noopReconciler.mountVirtualNode(element, hostParent, key)
-        expect(validatePropsSpy.callCount).to.equal(1)
-        validatePropsSpy:assertCalledWithDeepEqual({
-            a = 1
-        })
+		noopReconciler.mountVirtualNode(element, hostParent, key)
+		expect(validatePropsSpy.callCount).to.equal(1)
+		validatePropsSpy:assertCalledWithDeepEqual({
+			a = 1
+		})
 
-        setStateCallback({
-            b = 1
-        })
+		setStateCallback({
+			b = 1
+		})
 
-        expect(validatePropsSpy.callCount).to.equal(1)
-    end)
+		expect(validatePropsSpy.callCount).to.equal(1)
+	end)
 
-    it("should throw if validateProps is not a function", function()
-        local MyComponent = Component:extend("MyComponent")
-        MyComponent.validateProps = 1
+	it("should throw if validateProps is not a function", function()
+		local MyComponent = Component:extend("MyComponent")
+		MyComponent.validateProps = 1
 
-        function MyComponent:render()
-            return nil
-        end
+		function MyComponent:render()
+			return nil
+		end
 
-        local element = createElement(MyComponent)
+		local element = createElement(MyComponent)
 		local hostParent = nil
-        local key = "Test"
+		local key = "Test"
 
-        expect(function()
-            noopReconciler.mountVirtualNode(element, hostParent, key)
-        end).to.throw()
-    end)
+		expect(function()
+			noopReconciler.mountVirtualNode(element, hostParent, key)
+		end).to.throw()
+	end)
 
-    it("should throw if validateProps returns false", function()
-        local MyComponent = Component:extend("MyComponent")
-        MyComponent.validateProps = function()
-            return false
-        end
+	it("should throw if validateProps returns false", function()
+		local MyComponent = Component:extend("MyComponent")
+		MyComponent.validateProps = function()
+			return false
+		end
 
-        function MyComponent:render()
-            return nil
-        end
+		function MyComponent:render()
+			return nil
+		end
 
-        local element = createElement(MyComponent)
+		local element = createElement(MyComponent)
 		local hostParent = nil
-        local key = "Test"
+		local key = "Test"
 
-        expect(function()
-            noopReconciler.mountVirtualNode(element, hostParent, key)
-        end).to.throw()
+		expect(function()
+			noopReconciler.mountVirtualNode(element, hostParent, key)
+		end).to.throw()
 	end)
 
 	it("should be invoked after defaultProps are applied", function()
-        local MyComponent = Component:extend("MyComponent")
+		local MyComponent = Component:extend("MyComponent")
 
-        local validatePropsSpy = createSpy(function()
-            return true
-        end)
+		local validatePropsSpy = createSpy(function()
+			return true
+		end)
 
-        MyComponent.validateProps = validatePropsSpy.value
+		MyComponent.validateProps = validatePropsSpy.value
 
-        function MyComponent:render()
-            return nil
+		function MyComponent:render()
+			return nil
 		end
 
 		MyComponent.defaultProps = {
 			b = 2,
 		}
 
-        local element = createElement(MyComponent, { a = 1 })
+		local element = createElement(MyComponent, { a = 1 })
 		local hostParent = nil
-        local key = "Test"
+		local key = "Test"
 
-        local node = noopReconciler.mountVirtualNode(element, hostParent, key)
-        expect(validatePropsSpy.callCount).to.equal(1)
-        validatePropsSpy:assertCalledWithDeepEqual({
+		local node = noopReconciler.mountVirtualNode(element, hostParent, key)
+		expect(validatePropsSpy.callCount).to.equal(1)
+		validatePropsSpy:assertCalledWithDeepEqual({
 			a = 1,
 			b = 2,
-        })
+		})
 
-        local newElement = createElement(MyComponent, { a = 2 })
-        noopReconciler.updateVirtualNode(node, newElement)
-        expect(validatePropsSpy.callCount).to.equal(2)
-        validatePropsSpy:assertCalledWithDeepEqual({
+		local newElement = createElement(MyComponent, { a = 2 })
+		noopReconciler.updateVirtualNode(node, newElement)
+		expect(validatePropsSpy.callCount).to.equal(2)
+		validatePropsSpy:assertCalledWithDeepEqual({
 			a = 2,
 			b = 2,
-        })
-    end)
+		})
+	end)
 end

--- a/lib/Component.spec/validateProps.spec.lua
+++ b/lib/Component.spec/validateProps.spec.lua
@@ -131,5 +131,42 @@ return function()
         expect(function()
             noopReconciler.mountVirtualNode(element, hostParent, key)
         end).to.throw()
+	end)
+
+	it("should be invoked after defaultProps are applied", function()
+        local MyComponent = Component:extend("MyComponent")
+
+        local validatePropsSpy = createSpy(function()
+            return true
+        end)
+
+        MyComponent.validateProps = validatePropsSpy.value
+
+        function MyComponent:render()
+            return nil
+		end
+
+		MyComponent.defaultProps = {
+			b = 2,
+		}
+
+        local element = createElement(MyComponent, { a = 1 })
+		local hostParent = nil
+        local key = "Test"
+
+        local node = noopReconciler.mountVirtualNode(element, hostParent, key)
+        expect(validatePropsSpy.callCount).to.equal(1)
+        validatePropsSpy:assertCalledWithDeepEqual({
+			a = 1,
+			b = 2,
+        })
+
+        local newElement = createElement(MyComponent, { a = 2 })
+        noopReconciler.updateVirtualNode(node, newElement)
+        expect(validatePropsSpy.callCount).to.equal(2)
+        validatePropsSpy:assertCalledWithDeepEqual({
+			a = 2,
+			b = 2,
+        })
     end)
 end

--- a/lib/Config.lua
+++ b/lib/Config.lua
@@ -20,6 +20,8 @@ local defaultConfig = {
 	["componentInstrumentation"] = false,
 	-- Enables warnings if an element changes type after being rendered.
 	["warnOnTypeChange"] = true,
+	-- Enables validation of component props in stateful components.
+	["propertyValidation"] = false,
 }
 
 -- Build a list of valid configuration values up for debug messages.

--- a/lib/createSpy.lua
+++ b/lib/createSpy.lua
@@ -6,6 +6,8 @@
 	This should only be used in tests.
 ]]
 
+local assertDeepEqual = require(script.Parent.assertDeepEqual)
+
 local function createSpy(inner)
 	local self = {
 		callCount = 0,
@@ -37,6 +39,23 @@ local function createSpy(inner)
 			local expected = select(i, ...)
 
 			assert(self.values[i] == expected, "value differs")
+		end
+	end
+
+	self.assertCalledWithDeepEqual = function(_, ...)
+		local len = select("#", ...)
+
+		if self.valuesLength ~= len then
+			error(("Expected %d arguments, but was called with %d arguments"):format(
+				self.valuesLength,
+				len
+			), 2)
+		end
+
+		for i = 1, len do
+			local expected = select(i, ...)
+
+			assertDeepEqual(self.values[i], expected)
 		end
 	end
 


### PR DESCRIPTION
Supersedes #94; closes #24. Functionally the same as #94, but for the new reconciler instead! Briefly, this adds a new static method to components:

```
static validateProps(props: table) -> (false, message: string) | true
```

Every time props are updated, `validateProps` will be called with the new props before `shouldUpdate` and `init` are called. `validateProps` returns the same parameters that `assert` expects: a boolean, true if the props passed validation, false if they did not, plus a message explaining why they failed. If the first return value is true, the second value is ignored.

This is intended to be used with a type checking library like [PropTypes](https://github.com/AmaranthineCodices/rbx-prop-types) or [t](https://github.com/osyrisrblx/t).

One question remains about this: should this use GlobalConfig to conditionally disable it? I know we're looking to move away from GlobalConfig, so I'm not sure!

Checklist before submitting:
* [x] Added/updated relevant tests