### PR TITLE
Remove type change warning

### DIFF
--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -192,9 +192,6 @@ local function createReconciler(renderer)
 		end
 
 		if virtualNode.currentElement.component ~= newElement.component then
-			-- TODO: Better message
-			Logging.warn("Component changed type!")
-
 			return replaceVirtualNode(virtualNode, newElement)
 		end
 


### PR DESCRIPTION
Removes the warning when a component's type changes. We've found some very valid use cases for this, and the warning doesn't make much sense in light of them.