### PR TITLE
Xpcall

### DIFF
--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -171,7 +171,9 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 	local instance = Instance.new(element.component)
 	virtualNode.hostObject = instance
 
-	local success, errorMessage = pcall(applyProps, virtualNode, element.props)
+	local success, errorMessage = xpcall(function()
+		applyProps(virtualNode, element.props)
+	end, debug.traceback)
 
 	if not success then
 		local source = element.source
@@ -222,7 +224,9 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 		applyRef(newProps[Ref], virtualNode.hostObject)
 	end
 
-	local success, errorMessage = pcall(updateProps, virtualNode, oldProps, newProps)
+	local success, errorMessage = xpcall(function()
+		updateProps(virtualNode, oldProps, newProps)
+	end, debug.traceback)
 
 	if not success then
 		local source = newElement.source


### PR DESCRIPTION
Use `xpcall` when guarding property applications from errors. `xpcall` is slightly faster than `pcall`, and the benefit outweighs the cost of the additional closure creation. Below is a sample run of some benchmarks against these changes.

```
                         NewReconciler     NewReconcilerWithXpcall
fancy (x2000)            2.4519s           2.3837s (-2.8%)   
hello (x100000)          1.9688s           1.5947s (-19.0%)  
lifecycle (x100000)      1.1328s           1.0624s (-6.2%)   
nested-mount (x100000)   9.8486s           9.6178s (-2.3%)   
nested-update (x100000)  8.6277s           8.0045s (-7.2%)   
update (x100000)         1.1522s           0.9444s (-18.0%)  
```

Improvements are particularly noticeable in benchmarks that spend most of their time setting a single property of an instance (`hello` and `update`).

Additionally, I've wrapped the setting of binding values in `xpcall`.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* ~~Added/updated relevant tests~~
* ~~Added/updated documentation~~