### PR TITLE
Deprecate Roact.reconcile in favor of Roact.update in master

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Current `master` branch
 * Renamed `Roact.reify` to `Roact.mount` and `Roact.teardown` to `Roact.unmount` ([#82](https://github.com/Roblox/roact/issues/82))
 	* The old methods are still present as aliases, but will output a warning when used.
+* Renamed `Roact.reconcile` to `Roact.update` ([#194](https://github.com/Roblox/roact/pull/194))
+	* Like `Roact.reify` and `Roact.teardown`, the original method name is still available with a warning.
 * Added `Roact.Change` for subscribing to `GetPropertyChangedSignal` ([#51](https://github.com/Roblox/roact/pull/51))
 * Added the static lifecycle method `getDerivedStateFromProps` ([#57](https://github.com/Roblox/roact/pull/57))
 * Allow canceling render by returning nil from setState callback ([#64](https://github.com/Roblox/roact/pull/64))

--- a/lib/Component.lua
+++ b/lib/Component.lua
@@ -352,7 +352,7 @@ function Component:_forceUpdate(newProps, newState)
 	self._setStateBlockedReason = "reconcile"
 	if self._handle._child ~= nil then
 		-- We returned an element during our last render, update it.
-		self._handle._child = Reconciler._reconcileInternal(
+		self._handle._child = Reconciler._updateInternal(
 			self._handle._child,
 			newChildElement
 		)

--- a/lib/Component.spec.lua
+++ b/lib/Component.spec.lua
@@ -209,7 +209,7 @@ return function()
 		local state = getStateCallback()
 		expect(state.visible).to.equal(true)
 
-		handle = Reconciler.reconcile(handle, createElement(TestComponent, {
+		handle = Reconciler.update(handle, createElement(TestComponent, {
 			visible = 123
 		}))
 
@@ -283,7 +283,7 @@ return function()
 		end
 
 		local handle = Reconciler.mount(createElement(TestComponent, {}))
-		Reconciler.reconcile(handle, createElement(TestComponent, {
+		Reconciler.update(handle, createElement(TestComponent, {
 			baz = "!",
 		}))
 
@@ -317,7 +317,7 @@ return function()
 		expect(lastProps.foo).to.equal("hey")
 		expect(lastProps.bar).to.equal("world")
 
-		handle = Reconciler.reconcile(handle, createElement(TestComponent))
+		handle = Reconciler.update(handle, createElement(TestComponent))
 
 		expect(lastProps).to.be.a("table")
 		expect(lastProps.foo).to.equal("hello")
@@ -454,7 +454,7 @@ return function()
 			local handle = Reconciler.mount(element)
 
 			expect(function()
-				handle = Reconciler.reconcile(handle, {
+				handle = Reconciler.update(handle, {
 					createElement(TestComponent, {
 						someProp = 2
 					})

--- a/lib/Reconciler.lua
+++ b/lib/Reconciler.lua
@@ -4,7 +4,7 @@
 
 	The reonciler has three basic operations:
 	* mount (previously reify)
-	* reconcile
+	* update (previously reconcile)
 	* unmount (previously teardown)
 
 	Mounting is the process of creating new components. This is first
@@ -278,12 +278,12 @@ function Reconciler._mountInternal(element, parent, key, context)
 end
 
 --[[
-	A public interface around _reconcileInternal
+	A public interface around _updateInternal
 ]]
-function Reconciler.reconcile(instanceHandle, newElement)
+function Reconciler.update(instanceHandle, newElement)
 	if instanceHandle == nil or not instanceHandle[isInstanceHandle] then
 		local message = (
-			"Bad argument #1 to Reconciler.reconcile, expected component instance handle, found %s"
+			"Bad argument #1 to Reconciler.update, expected component instance handle, found %s"
 		):format(
 			typeof(instanceHandle)
 		)
@@ -291,7 +291,7 @@ function Reconciler.reconcile(instanceHandle, newElement)
 		error(message, 2)
 	end
 
-	return Reconciler._reconcileInternal(instanceHandle, newElement)
+	return Reconciler._updateInternal(instanceHandle, newElement)
 end
 
 --[[
@@ -300,7 +300,7 @@ end
 	reconcile will return the instance that should be used. This instance can
 	be different than the one that was passed in.
 ]]
-function Reconciler._reconcileInternal(instanceHandle, newElement)
+function Reconciler._updateInternal(instanceHandle, newElement)
 	local oldElement = instanceHandle._element
 
 	local newElementKind = getElementKind(newElement)
@@ -375,7 +375,7 @@ function Reconciler._reconcileInternal(instanceHandle, newElement)
 
 		if instanceHandle._child then
 			-- Transition from tree to tree, even if 'rendered' is nil
-			newChild = Reconciler._reconcileInternal(instanceHandle._child, rendered)
+			newChild = Reconciler._updateInternal(instanceHandle._child, rendered)
 		elseif rendered then
 			-- Transition from nil to new tree
 			newChild = Reconciler._mountInternal(
@@ -429,7 +429,7 @@ function Reconciler._reconcilePrimitiveChildren(instance, newElement)
 	for key, childInstance in pairs(instance._children) do
 		local childElement = elementChildren and elementChildren[key]
 
-		childInstance = Reconciler._reconcileInternal(childInstance, childElement)
+		childInstance = Reconciler._updateInternal(childInstance, childElement)
 
 		instance._children[key] = childInstance
 	end

--- a/lib/Reconciler.spec.lua
+++ b/lib/Reconciler.spec.lua
@@ -59,7 +59,7 @@ return function()
 		local handle = Reconciler.mount(element, game, "Test123")
 		expect(aValue).to.be.ok()
 		expect(bValue).to.never.be.ok()
-		handle = Reconciler.reconcile(handle, createElement("StringValue", {
+		handle = Reconciler.update(handle, createElement("StringValue", {
 			[Core.Ref] = bRef,
 		}))
 		expect(aValue).to.never.be.ok()
@@ -79,7 +79,7 @@ return function()
 		local handle = Reconciler.mount(element, game, "Test123")
 		expect(aRef.current).to.be.ok()
 		expect(bRef.current).to.never.be.ok()
-		handle = Reconciler.reconcile(handle, createElement("StringValue", {
+		handle = Reconciler.update(handle, createElement("StringValue", {
 			[Core.Ref] = bRef,
 		}))
 		expect(aRef.current).to.never.be.ok()
@@ -110,7 +110,7 @@ return function()
 		container.Foo.Size = UDim2.new(0, 100, 0, 100)
 		expect(sizeChangedCount).to.equal(1)
 
-		handle = Reconciler.reconcile(handle, createElement("Frame", {
+		handle = Reconciler.update(handle, createElement("Frame", {
 			[Event.Changed] = nil
 		}))
 		container.Foo.Size = UDim2.new(0, 200, 0, 200)
@@ -139,7 +139,7 @@ return function()
 		container.Foo.Size = UDim2.new(0, 100, 0, 100)
 		expect(sizeChangedCount).to.equal(1)
 
-		handle = Reconciler.reconcile(handle, createElement("Frame", {
+		handle = Reconciler.update(handle, createElement("Frame", {
 			[Change.Size] = nil
 		}))
 		container.Foo.Size = UDim2.new(0, 200, 0, 200)

--- a/lib/ReconcilerCompat.lua
+++ b/lib/ReconcilerCompat.lua
@@ -17,6 +17,11 @@ Roact.teardown has been renamed to Roact.unmount and will be removed in a future
 Check the call to Roact.teardown at:
 ]]
 
+local reconcileMessage = [[
+Roact.reconcile has been renamed to Roact.update and will be removed in a future release.
+Check the call to Roact.reconcile at:
+]]
+
 local ReconcilerCompat = {}
 
 --[[
@@ -45,6 +50,12 @@ function ReconcilerCompat.teardown(...)
 	warnOnce(teardownMessage)
 
 	return Reconciler.unmount(...)
+end
+
+function ReconcilerCompat.reconcile(...)
+	warnOnce(reconcileMessage)
+
+	return Reconciler.update(...)
 end
 
 return ReconcilerCompat

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -25,10 +25,11 @@ local Roact = {
 
 	mount = Reconciler.mount,
 	unmount = Reconciler.unmount,
-	reconcile = Reconciler.reconcile,
+	update = Reconciler.update,
 
 	reify = ReconcilerCompat.reify,
 	teardown = ReconcilerCompat.teardown,
+	reconcile = ReconcilerCompat.reconcile,
 
 	setGlobalConfig = GlobalConfig.set,
 	getGlobalConfigValue = GlobalConfig.getValue,

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -7,14 +7,15 @@ return function()
 			createRef = "function",
 			mount = "function",
 			unmount = "function",
-			reconcile = "function",
+			update = "function",
 			oneChild = "function",
 			setGlobalConfig = "function",
 			getGlobalConfigValue = "function",
 
-			-- These functions are deprecated and will throw warnings soon!
+			-- These functions are deprecated and throw warnings!
 			reify = "function",
 			teardown = "function",
+			reconcile = "function",
 
 			Component = true,
 			PureComponent = true,


### PR DESCRIPTION
As a step to trying to make user's code more compatible in preparation for `new-reconciler` merging back in, this PR deprecates `Roact.reconcile` in favor of `Roact.update`, which is more clear.

`Roact.reconcile` was already deprecated in the `new-reconciler` branch awhile ago. 

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* ~Added/updated documentation~ (#193)