### PR TITLE
Remove undocumented APIs `getGlobalConfigValue` and `Element`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
 * `setState` can now be called inside `init` and `willUpdate`. Instead of triggering a new render, it will affect the currently scheduled one. ([#139](https://github.com/Roblox/roact/pull/139))
 * Roll back changes that allowed `setState` to be called inside `willUpdate`, which created state update scenarios with difficult-to-determine behavior. ([#157](https://github.com/Roblox/roact/pull/157))
 * By default, disable the warning for an element changing types during reconciliation ([#168](https://github.com/Roblox/roact/pull/168))
+* Removed some undocumented APIs:
+	* `Roact.getGlobalConfigValue`, which let users read the current internal configuration.
+	* `Roact.Element`, which let users figure out whether something is a Roact element. We'll introduce a proper type-checking API at a later date.
 
 ## 1.0.0 Prerelease 2 (March 22, 2018)
 * Removed `is*Element` methods, this is unlikely to affect anyone ([#50](https://github.com/Roblox/roact/pull/50))

--- a/lib/init.lua
+++ b/lib/init.lua
@@ -18,7 +18,6 @@ local Roact = {
 	PureComponent = require(script.PureComponent),
 
 	Children = Core.Children,
-	Element = Core.Element,
 	None = Core.None,
 	Portal = Core.Portal,
 	Ref = Core.Ref,
@@ -31,7 +30,6 @@ local Roact = {
 	teardown = ReconcilerCompat.teardown,
 
 	setGlobalConfig = GlobalConfig.set,
-	getGlobalConfigValue = GlobalConfig.getValue,
 
 	-- APIs that may change in the future without warning
 	UNSTABLE = {

--- a/lib/init.spec.lua
+++ b/lib/init.spec.lua
@@ -10,7 +10,6 @@ return function()
 			reconcile = "function",
 			oneChild = "function",
 			setGlobalConfig = "function",
-			getGlobalConfigValue = "function",
 
 			-- These functions are deprecated and will throw warnings soon!
 			reify = "function",
@@ -24,7 +23,6 @@ return function()
 			Change = true,
 			Ref = true,
 			None = true,
-			Element = true,
 			UNSTABLE = true,
 		}
 


### PR DESCRIPTION
This PR removes two undocumented APIs that aren't very useful and aren't present in the `new-reconciler` branch.

- `Roact.getGlobalConfigValue`, which let users read the current global configuration. I think we introduced this to try to allow for user-land property validation, but that didn't pan out.
- `Roact.Element`, which lets users figure out whether something is a Roact element. We should re-introduce a typechecking API like the internal one in `new-reconciler`.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* ~Added/updated documentation~ hah, documentation