### PR TITLE
Change misleading code in Roact.Change example

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -142,8 +142,8 @@ It's similar to `Roact.Event`:
 
 ```lua
 Roact.createElement("ScrollingFrame", {
-	[Roact.Change.CanvasPosition] = function(rbx, position)
-		print("ScrollingFrame scrolled to", position)
+	[Roact.Change.CanvasPosition] = function(rbx)
+		print("ScrollingFrame scrolled to", rbx.CanvasPosition)
 	end,
 })
 ```


### PR DESCRIPTION
GetPropertyChangedSignal does not pass the new value of the property to the function and the Roact.Change handler doesn't add this functionality so the current example code is slightly misleading.