### PR TITLE
Hide tree internals

### DIFF
--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -345,7 +345,7 @@ local function createReconciler(renderer)
 				-- Roact component instances.
 				rootNode = nil,
 				mounted = true,
-			}
+			},
 		}
 
 		tree[InternalData].rootNode = mountVirtualNode(element, hostParent, hostKey)
@@ -360,16 +360,16 @@ local function createReconciler(renderer)
 		unmounted, as indicated by its the `mounted` field.
 	]]
 	local function unmountVirtualTree(tree)
+		local internalData = tree[InternalData]
 		if config.typeChecks then
 			assert(Type.of(tree) == Type.VirtualTree, "Expected arg #1 to be a Roact handle")
-			assert(tree[InternalData].mounted, "Cannot unmounted a Roact tree that has already been unmounted")
+			assert(internalData.mounted, "Cannot unmounted a Roact tree that has already been unmounted")
 		end
 
-		tree[InternalData].mounted = false
+		internalData.mounted = false
 
-		local rootNode = tree[InternalData].rootNode
-		if rootNode ~= nil then
-			unmountVirtualNode(rootNode)
+		if internalData.rootNode ~= nil then
+			unmountVirtualNode(internalData.rootNode)
 		end
 	end
 
@@ -378,12 +378,13 @@ local function createReconciler(renderer)
 		element.
 	]]
 	local function updateVirtualTree(tree, newElement)
+		local internalData = tree[InternalData]
 		if config.typeChecks then
 			assert(Type.of(tree) == Type.VirtualTree, "Expected arg #1 to be a Roact handle")
 			assert(Type.of(newElement) == Type.Element, "Expected arg #2 to be a Roact Element")
 		end
 
-		tree[InternalData].rootNode = updateVirtualNode(tree[InternalData].rootNode, newElement)
+		internalData.rootNode = updateVirtualNode(internalData.rootNode, newElement)
 
 		return tree
 	end

--- a/lib/createReconciler.lua
+++ b/lib/createReconciler.lua
@@ -2,9 +2,12 @@ local Type = require(script.Parent.Type)
 local ElementKind = require(script.Parent.ElementKind)
 local ElementUtils = require(script.Parent.ElementUtils)
 local Children = require(script.Parent.PropMarkers.Children)
+local Symbol = require(script.Parent.Symbol)
 local internalAssert = require(script.Parent.internalAssert)
 
 local config = require(script.Parent.GlobalConfig).get()
+
+local InternalData = Symbol.named("InternalData")
 
 --[[
 	The reconciler is the mechanism in Roact that constructs the virtual tree
@@ -337,17 +340,15 @@ local function createReconciler(renderer)
 
 		local tree = {
 			[Type] = Type.VirtualTree,
-
-			-- TODO: Move these fields into an internal data table?
-
-			-- The root node of the tree, which starts into the hierarchy of
-			-- Roact component instances.
-			rootNode = nil,
-
-			mounted = true,
+			[InternalData] = {
+				-- The root node of the tree, which starts into the hierarchy of
+				-- Roact component instances.
+				rootNode = nil,
+				mounted = true,
+			}
 		}
 
-		tree.rootNode = mountVirtualNode(element, hostParent, hostKey)
+		tree[InternalData].rootNode = mountVirtualNode(element, hostParent, hostKey)
 
 		return tree
 	end
@@ -361,13 +362,14 @@ local function createReconciler(renderer)
 	local function unmountVirtualTree(tree)
 		if config.typeChecks then
 			assert(Type.of(tree) == Type.VirtualTree, "Expected arg #1 to be a Roact handle")
-			assert(tree.mounted, "Cannot unmounted a Roact tree that has already been unmounted")
+			assert(tree[InternalData].mounted, "Cannot unmounted a Roact tree that has already been unmounted")
 		end
 
-		tree.mounted = false
+		tree[InternalData].mounted = false
 
-		if tree.rootNode ~= nil then
-			unmountVirtualNode(tree.rootNode)
+		local rootNode = tree[InternalData].rootNode
+		if rootNode ~= nil then
+			unmountVirtualNode(rootNode)
 		end
 	end
 
@@ -381,7 +383,7 @@ local function createReconciler(renderer)
 			assert(Type.of(newElement) == Type.Element, "Expected arg #2 to be a Roact Element")
 		end
 
-		tree.rootNode = updateVirtualNode(tree.rootNode, newElement)
+		tree[InternalData].rootNode = updateVirtualNode(tree[InternalData].rootNode, newElement)
 
 		return tree
 	end

--- a/lib/createReconciler.spec.lua
+++ b/lib/createReconciler.spec.lua
@@ -23,11 +23,8 @@ return function()
 			local tree = noopReconciler.mountVirtualTree(createElement("StringValue"))
 
 			expect(tree).to.be.ok()
-			expect(tree.rootNode).to.be.ok()
 
 			noopReconciler.updateVirtualTree(tree, createElement("StringValue"))
-
-			expect(tree.rootNode).to.be.ok()
 
 			noopReconciler.unmountVirtualTree(tree)
 		end)


### PR DESCRIPTION
Better not to let people depend on internals.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* [x] Added/updated relevant tests
* ~~Added/updated documentation~~