### PR TITLE
Restore event suspension

### DIFF
--- a/lib/RobloxRenderer.lua
+++ b/lib/RobloxRenderer.lua
@@ -219,6 +219,10 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 	virtualNode.hostObject = instance
 
 	applyRef(element.props[Ref], instance)
+
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:resume()
+	end
 end
 
 function RobloxRenderer.unmountHostNode(reconciler, virtualNode)
@@ -238,6 +242,10 @@ end
 function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 	local oldProps = virtualNode.currentElement.props
 	local newProps = newElement.props
+
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:suspend()
+	end
 
 	-- If refs changed, detach the old ref and attach the new one
 	if oldProps[Ref] ~= newProps[Ref] then
@@ -263,6 +271,10 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 	local children = newElement.props[Children]
 	if children ~= nil then
 		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
+	end
+
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:resume()
 	end
 
 	return virtualNode

--- a/lib/SingleEventManager.lua
+++ b/lib/SingleEventManager.lua
@@ -1,13 +1,30 @@
 --[[
 	A manager for a single host virtual node's connected events.
 ]]
+
+local Logging = require(script.Parent.Logging)
+
 local CHANGE_PREFIX = "Change."
+
+local EventStatus = {
+	-- No events are processed at all; they're silently discarded
+	Disabled = "Disabled",
+
+	-- Events are stored in a queue; listeners are invoked when the manager is resumed
+	Suspended = "Suspended",
+
+	-- Event listeners are invoked as the events fire
+	Enabled = "Enabled",
+}
 
 local SingleEventManager = {}
 SingleEventManager.__index = SingleEventManager
 
 function SingleEventManager.new(instance)
 	local self = setmetatable({
+		-- The queue of suspended events
+		_suspendedEventQueue = {},
+
 		-- All the event connections being managed
 		-- Events are indexed by a string key
 		_connections = {},
@@ -16,6 +33,13 @@ function SingleEventManager.new(instance)
 		-- These are stored distinctly from the connections
 		-- Connections can have their listeners replaced at runtime
 		_listeners = {},
+
+		-- The suspension status of the manager
+		-- Managers start disabled and are "resumed" after the initial render
+		_status = EventStatus.Disabled,
+
+		-- If true, the manager is processing queued events right now.
+		_isResuming = false,
 
 		-- The Roblox instance the manager is managing
 		_instance = instance,
@@ -45,12 +69,69 @@ function SingleEventManager:_connect(eventKey, event, listener)
 	else
 		if self._connections[eventKey] == nil then
 			self._connections[eventKey] = event:Connect(function(...)
-				self._listeners[eventKey](self._instance, ...)
+				if self._status == EventStatus.Enabled then
+					self._listeners[eventKey](self._instance, ...)
+				elseif self._status == EventStatus.Suspended then
+					-- Store this event invocation to be fired when resume is
+					-- called.
+
+					local argumentCount = select("#", ...)
+					table.insert(self._suspendedEventQueue, { eventKey, argumentCount, ... })
+				end
 			end)
 		end
 
 		self._listeners[eventKey] = listener
 	end
+end
+
+function SingleEventManager:suspend()
+	self._status = EventStatus.Suspended
+end
+
+function SingleEventManager:resume()
+	-- If we're already resuming events for this instance, trying to resume
+	-- again would cause a disaster.
+	if self._isResuming then
+		return
+	end
+
+	self._isResuming = true
+
+	local index = 1
+
+	-- More events might be added to the queue when evaluating events, so we
+	-- need to be careful in order to preserve correct evaluation order.
+	while index <= #self._suspendedEventQueue do
+		local eventInvocation = self._suspendedEventQueue[index]
+		local listener = self._listeners[eventInvocation[1]]
+		local argumentCount = eventInvocation[2]
+
+		-- The event might have been disconnected since suspension started; in
+		-- this case, we drop the event.
+		if listener ~= nil then
+			-- Wrap the listener in a coroutine to catch errors and handle
+			-- yielding correctly.
+			local listenerCo = coroutine.create(listener)
+			local success, result = coroutine.resume(
+				listenerCo,
+				self._instance,
+				unpack(eventInvocation, 3, 2 + argumentCount))
+
+			-- If the listener threw an error, we log it as a warning, since
+			-- there's no way to write error text in Roblox Lua without killing
+			-- our thread!
+			if not success then
+				Logging.warn("%s", result)
+			end
+		end
+
+		index = index + 1
+	end
+
+	self._isResuming = false
+	self._status = EventStatus.Enabled
+	self._suspendedEventQueue = {}
 end
 
 return SingleEventManager

--- a/lib/SingleEventManager.spec.lua
+++ b/lib/SingleEventManager.spec.lua
@@ -1,5 +1,7 @@
 return function()
+	local assertDeepEqual = require(script.Parent.assertDeepEqual)
 	local createSpy = require(script.Parent.createSpy)
+	local Logging = require(script.Parent.Logging)
 
 	local SingleEventManager = require(script.Parent.SingleEventManager)
 
@@ -11,13 +13,14 @@ return function()
 		end)
 	end)
 
-	describe("connections", function()
+	describe("connectEvent", function()
 		it("should connect to events", function()
 			local instance = Instance.new("BindableEvent")
 			local manager = SingleEventManager.new(instance)
 			local eventSpy = createSpy()
 
 			manager:connectEvent("Event", eventSpy.value)
+			manager:resume()
 
 			instance:Fire("foo")
 			expect(eventSpy.callCount).to.equal(1)
@@ -33,12 +36,182 @@ return function()
 			expect(eventSpy.callCount).to.equal(2)
 		end)
 
+		it("should drop events until resumed initially", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+			local eventSpy = createSpy()
+
+			manager:connectEvent("Event", eventSpy.value)
+
+			instance:Fire("foo")
+			expect(eventSpy.callCount).to.equal(0)
+
+			manager:resume()
+
+			instance:Fire("bar")
+			expect(eventSpy.callCount).to.equal(1)
+			eventSpy:assertCalledWith(instance, "bar")
+		end)
+
+		it("should invoke suspended events when resumed", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+			local eventSpy = createSpy()
+
+			manager:connectEvent("Event", eventSpy.value)
+			manager:resume()
+
+			instance:Fire("foo")
+			expect(eventSpy.callCount).to.equal(1)
+			eventSpy:assertCalledWith(instance, "foo")
+
+			manager:suspend()
+
+			instance:Fire("bar")
+			expect(eventSpy.callCount).to.equal(1)
+
+			manager:resume()
+			expect(eventSpy.callCount).to.equal(2)
+			eventSpy:assertCalledWith(instance, "bar")
+		end)
+
+		it("should invoke events triggered during resumption in the correct order", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+
+			local recordedValues = {}
+			local eventSpy = createSpy(function(_, value)
+				table.insert(recordedValues, value)
+
+				if value == 2 then
+					instance:Fire(3)
+				elseif value == 3 then
+					instance:Fire(4)
+				end
+			end)
+
+			manager:connectEvent("Event", eventSpy.value)
+			manager:suspend()
+
+			instance:Fire(1)
+			instance:Fire(2)
+
+			manager:resume()
+			expect(eventSpy.callCount).to.equal(4)
+			assertDeepEqual(recordedValues, {1, 2, 3, 4})
+		end)
+
+		it("should not invoke events fired during suspension but disconnected before resumption", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+			local eventSpy = createSpy()
+
+			manager:connectEvent("Event", eventSpy.value)
+			manager:suspend()
+
+			instance:Fire(1)
+
+			manager:connectEvent("Event", nil)
+
+			manager:resume()
+			expect(eventSpy.callCount).to.equal(0)
+		end)
+
+		it("should not yield events through the SingleEventManager when resuming", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+
+			manager:connectEvent("Event", function()
+				coroutine.yield()
+			end)
+
+			manager:resume()
+
+			local co = coroutine.create(function()
+				instance:Fire(5)
+			end)
+
+			assert(coroutine.resume(co))
+			expect(coroutine.status(co)).to.equal("dead")
+
+			manager:suspend()
+			instance:Fire(5)
+
+			co = coroutine.create(function()
+				manager:resume()
+			end)
+
+			assert(coroutine.resume(co))
+			expect(coroutine.status(co)).to.equal("dead")
+		end)
+
+		it("should not throw errors through SingleEventManager when resuming", function()
+			local errorText = "Error from SingleEventManager test"
+
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+
+			manager:connectEvent("Event", function()
+				error(errorText)
+			end)
+
+			manager:resume()
+
+			-- If we call instance:Fire() here, the error message will leak to
+			-- the console since the thread's resumption will be handled by
+			-- Roblox's scheduler.
+
+			manager:suspend()
+			instance:Fire(5)
+
+			local logInfo = Logging.capture(function()
+				manager:resume()
+			end)
+
+			expect(#logInfo.errors).to.equal(0)
+			expect(#logInfo.warnings).to.equal(1)
+			expect(#logInfo.infos).to.equal(0)
+
+			expect(logInfo.warnings[1]:find(errorText)).to.be.ok()
+		end)
+
+		it("should not overflow with events if manager:resume() is invoked when resuming a suspended event", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+
+			-- This connection emulates what happens if reconciliation is
+			-- triggered again in response to reconciliation. Without
+			-- appropriate guards, the inner resume() call will process the
+			-- Fire(1) event again, causing a nasty stack overflow.
+			local eventSpy = createSpy(function(_, value)
+				if value == 1 then
+					manager:suspend()
+					instance:Fire(2)
+					manager:resume()
+				end
+			end)
+
+			manager:connectEvent("Event", eventSpy.value)
+
+			manager:suspend()
+			instance:Fire(1)
+			manager:resume()
+
+			expect(eventSpy.callCount).to.equal(2)
+		end)
+	end)
+
+	describe("connectPropertyChange", function()
+		-- Since property changes utilize the same mechanisms as other events,
+		-- the tests here are slimmed down to reduce redundancy.
+
 		it("should connect to property changes", function()
 			local instance = Instance.new("Folder")
 			local manager = SingleEventManager.new(instance)
 			local eventSpy = createSpy()
 
 			manager:connectPropertyChange("Name", eventSpy.value)
+			manager:resume()
 
 			instance.Name = "foo"
 			expect(eventSpy.callCount).to.equal(1)


### PR DESCRIPTION
Restores event suspension, which was removed by setState suspension (#183). We're reintroducing this behavior because events can fire while updating properties, which allows you to observe the Roblox instance in an intermediate state that you _probably_ don't want to be doing any calculations on.