### PR TITLE
joinBindings implementation

### DIFF
--- a/src/Binding.lua
+++ b/src/Binding.lua
@@ -206,6 +206,17 @@ end
 	be exposed to users of Roact.
 ]]
 function Binding.join(bindings)
+	if config.typeChecks then
+		assert(typeof(bindings) == "table", "Bad arg #1 to Binding.join: expected table")
+
+		for key, binding in pairs(bindings) do
+			--[[
+				Bindings exclusively and always have a InternalData member
+			]]
+			assert(binding[InternalData], ("Non-binding value passed into Binding.join at index %q"):format(key))
+		end
+	end
+
 	local joinedBinding = Binding.create(mapBindingsToValues(bindings))
 	local internalData = joinedBinding[InternalData]
 

--- a/src/Binding.lua
+++ b/src/Binding.lua
@@ -108,9 +108,11 @@ end
 function bindingPrototype:__upstreamDisconnect()
 	local internalData = self[InternalData]
 
-	for _, disconnect in pairs(internalData.upstreamConnections) do
+	for _, disconnect in ipairs(internalData.upstreamConnections) do
 		disconnect()
 	end
+
+	internalData.upstreamConnections = {}
 end
 
 --[[

--- a/src/Binding.lua
+++ b/src/Binding.lua
@@ -218,7 +218,7 @@ function Binding.join(bindings)
 			--[[
 				Bindings exclusively and always have a InternalData member
 			]]
-			assert(binding[InternalData], ("Non-binding value passed into Binding.join at index %q"):format(key))
+			assert(Type.of(binding) == Type.Binding, ("Non-binding value passed into Binding.join at index %q"):format(key))
 		end
 	end
 

--- a/src/Binding.lua
+++ b/src/Binding.lua
@@ -170,7 +170,7 @@ function Binding.join(bindings)
 
 	local upstreamConnections = {}
 	internalData.upstreamConnections = upstreamConnections
-	
+
 	internalData.upstreamDisconnect = function()
 		for _, disconnect in pairs(upstreamConnections) do
 			disconnect()

--- a/src/Binding.lua
+++ b/src/Binding.lua
@@ -69,7 +69,7 @@ function bindingPrototype:map(valueTransform)
 	local internalData = binding[InternalData]
 
 	internalData.valueTransform = valueTransform
-	
+
 	internalData.upstreamBindings.source = self
 	internalData.upstreamBindingCount = internalData.upstreamBindingCount + 1
 
@@ -137,8 +137,8 @@ function Binding.subscribe(binding, handler)
 			Binding.update(binding, binding:__getValueFromUpstreamBindings())
 		end
 
-		for _, binding in pairs(internalData.upstreamBindings) do
-			table.insert(internalData.upstreamConnections, Binding.subscribe(binding, upstreamCallback))
+		for _, upstreamBinding in pairs(internalData.upstreamBindings) do
+			table.insert(internalData.upstreamConnections, Binding.subscribe(upstreamBinding, upstreamCallback))
 		end
 	end
 

--- a/src/Binding.lua
+++ b/src/Binding.lua
@@ -215,9 +215,6 @@ function Binding.join(bindings)
 		assert(typeof(bindings) == "table", "Bad arg #1 to Binding.join: expected table")
 
 		for key, binding in pairs(bindings) do
-			--[[
-				Bindings exclusively and always have a InternalData member
-			]]
 			assert(Type.of(binding) == Type.Binding, ("Non-binding value passed into Binding.join at index %q"):format(key))
 		end
 	end

--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -81,15 +81,15 @@ return function()
 
 		it("should throw when a non-table value is passed", function()
 			expect(function()
-				Roact.joinBindings("hi")
+				Binding.join("hi")
 			end).to.throw()
 		end)
 
 		it("should throw when a non-binding value is passed via table", function()
 			expect(function()
-				local binding = Roact.createBinding(123)
+				local binding = Binding.create(123)
 
-				Roact.joinBindings({
+				Binding.join({
 					binding,
 					"abcde",
 				})

--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -55,10 +55,28 @@ return function()
 			update2(4)
 			expect(spy.callCount).to.equal(2)
 
-			local bindingValue = joinedBinding:getValue()
+			local bindingValue = spy.values[1]
 			expect(bindingValue).to.be.a("table")
 			expect(bindingValue[1]).to.equal(3)
 			expect(bindingValue[2]).to.equal(4)
+		end)
+
+		it("should return correct values when there are no subscriptions", function()
+			local binding1, update1 = Binding.create(1)
+			local binding2, update2 = Binding.create(2)
+
+			local joinedBinding = Binding.join({
+				binding1,
+				binding2,
+			})
+
+			update1("foo")
+			update2("bar")
+
+			local bindingValue = joinedBinding:getValue()
+			expect(bindingValue).to.be.a("table")
+			expect(bindingValue[1]).to.equal("foo")
+			expect(bindingValue[2]).to.equal("bar")
 		end)
 
 		it("should throw when a non-table value is passed", function()

--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -60,6 +60,23 @@ return function()
 			expect(bindingValue[1]).to.equal(3)
 			expect(bindingValue[2]).to.equal(4)
 		end)
+
+		it("should throw when a non-table value is passed", function()
+			expect(function()
+				Roact.joinBindings("hi")
+			end).to.throw()
+		end)
+
+		it("should throw when a non-binding value is passed via table", function()
+			expect(function()
+				local binding = Roact.createBinding(123)
+
+				Roact.joinBindings({
+					binding,
+					"abcde",
+				})
+			end).to.throw()
+		end)
 	end)
 
 	describe("Binding object", function()

--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -23,8 +23,8 @@ return function()
 
 	describe("Binding.join", function()
 		it("should properly output values", function()
-			local binding1, update1 = Binding.create(1)
-			local binding2, update2 = Binding.create(2)
+			local binding1 = Binding.create(1)
+			local binding2 = Binding.create(2)
 
 			local joinedBinding = Binding.join({
 				binding1,
@@ -47,18 +47,18 @@ return function()
 			})
 
 			local spy = createSpy()
-			local disconnect = Binding.subscribe(joinedBinding, spy.value)
+			Binding.subscribe(joinedBinding, spy.value)
 
 			expect(spy.callCount).to.equal(0)
-
 			update1(3)
-
 			expect(spy.callCount).to.equal(1)
+			update2(4)
+			expect(spy.callCount).to.equal(2)
 
 			local bindingValue = spy.values[1]
 			expect(bindingValue).to.be.a("table")
 			expect(bindingValue[1]).to.equal(3)
-			expect(bindingValue[2]).to.equal(2)
+			expect(bindingValue[2]).to.equal(4)
 		end)
 	end)
 

--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -21,6 +21,47 @@ return function()
 		end)
 	end)
 
+	describe("Binding.join", function()
+		it("should properly output values", function()
+			local binding1, update1 = Binding.create(1)
+			local binding2, update2 = Binding.create(2)
+
+			local joinedBinding = Binding.join({
+				binding1,
+				binding2,
+			})
+
+			local bindingValue = joinedBinding:getValue()
+			expect(bindingValue).to.be.a("table")
+			expect(bindingValue[1]).to.equal(1)
+			expect(bindingValue[2]).to.equal(2)
+		end)
+
+		it("should update when any one of the subscribed bindings updates", function()
+			local binding1, update1 = Binding.create(1)
+			local binding2, update2 = Binding.create(2)
+
+			local joinedBinding = Binding.join({
+				binding1,
+				binding2,
+			})
+
+			local spy = createSpy()
+			local disconnect = Binding.subscribe(joinedBinding, spy.value)
+
+			expect(spy.callCount).to.equal(0)
+
+			update1(3)
+
+			expect(spy.callCount).to.equal(1)
+
+			local bindingValue = spy.values[1]
+			expect(bindingValue).to.be.a("table")
+			expect(bindingValue[1]).to.equal(3)
+			expect(bindingValue[2]).to.equal(2)
+		end)
+	end)
+
 	describe("Binding object", function()
 		it("should provide a getter and setter", function()
 			local binding, update = Binding.create(1)

--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -55,7 +55,7 @@ return function()
 			update2(4)
 			expect(spy.callCount).to.equal(2)
 
-			local bindingValue = spy.values[1]
+			local bindingValue = joinedBinding:getValue()
 			expect(bindingValue).to.be.a("table")
 			expect(bindingValue[1]).to.equal(3)
 			expect(bindingValue[2]).to.equal(4)

--- a/src/init.lua
+++ b/src/init.lua
@@ -22,6 +22,7 @@ local Roact = strict {
 	Portal = require(script.Portal),
 	createRef = require(script.createRef),
 	createBinding = Binding.create,
+	joinBindings = Binding.join,
 
 	Change = require(script.PropMarkers.Change),
 	Children = require(script.PropMarkers.Children),

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -7,6 +7,7 @@ return function()
 			createFragment = "function",
 			createRef = "function",
 			createBinding = "function",
+			joinBindings = "function",
 			mount = "function",
 			unmount = "function",
 			update = "function",


### PR DESCRIPTION
Implements a function that creates a new binding, which updates whenever any of the bindings passed (via table) updates. Internally as `Binding.join`; public API is `Roact.joinBindings`.

Example usage:

```lua
local colorBinding = Roact.joinBindings({
	hue = hueBinding,
	saturation = saturationBinding,
	value = valueBinding,
}):map(function(values)
	return Color3.fromHSV(values.hue, values.saturation, values.value)
end)
```