### PR TITLE
Remove children when updating a host node to an element with nil children

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-* Fixed an issue where updating a host element with children to an element with `nil` children caused the old children to not be unmounted.
+* Fixed an issue where updating a host element with children to an element with `nil` children caused the old children to not be unmounted. ([#210](https://github.com/Roblox/roact/pull/210))
 
 ## [1.0.0](https://github.com/Roblox/roact/releases/tag/v1.0.0)
 This release significantly reworks Roact internals to enable new features and optimizations.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Roact Changelog
 
+## Unreleased
+
+* Fixed an issue where updating a host element with children to an element with `nil` children caused the old children to not be unmounted.
+
 ## [1.0.0](https://github.com/Roblox/roact/releases/tag/v1.0.0)
 This release significantly reworks Roact internals to enable new features and optimizations.
 

--- a/src/RobloxRenderer.lua
+++ b/src/RobloxRenderer.lua
@@ -271,7 +271,7 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 	local children = newElement.props[Children]
 
 	if children ~= nil or oldProps[Children] ~= nil then
-		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
+		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
 	end
 
 	if virtualNode.eventManager ~= nil then

--- a/src/RobloxRenderer.lua
+++ b/src/RobloxRenderer.lua
@@ -269,7 +269,6 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 	end
 
 	local children = newElement.props[Children]
-
 	if children ~= nil or oldProps[Children] ~= nil then
 		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
 	end

--- a/src/RobloxRenderer.lua
+++ b/src/RobloxRenderer.lua
@@ -211,7 +211,9 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 
 	local children = element.props[Children]
 
-	reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
+	if children ~= nil then
+		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
+	end
 
 	instance.Parent = hostParent
 	virtualNode.hostObject = instance
@@ -266,7 +268,11 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 		error(fullMessage, 0)
 	end
 
-	reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
+	local children = newElement.props[Children]
+
+	if children ~= nil or oldProps[Children] ~= nil then
+		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
+	end
 
 	if virtualNode.eventManager ~= nil then
 		virtualNode.eventManager:resume()

--- a/src/RobloxRenderer.lua
+++ b/src/RobloxRenderer.lua
@@ -211,9 +211,7 @@ function RobloxRenderer.mountHostNode(reconciler, virtualNode)
 
 	local children = element.props[Children]
 
-	if children ~= nil then
-		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
-	end
+	reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
 
 	instance.Parent = hostParent
 	virtualNode.hostObject = instance
@@ -268,10 +266,7 @@ function RobloxRenderer.updateHostNode(reconciler, virtualNode, newElement)
 		error(fullMessage, 0)
 	end
 
-	local children = newElement.props[Children]
-	if children ~= nil then
-		reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, children)
-	end
+	reconciler.updateVirtualNodeWithChildren(virtualNode, virtualNode.hostObject, newElement.props[Children])
 
 	if virtualNode.eventManager ~= nil then
 		virtualNode.eventManager:resume()

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -419,6 +419,33 @@ return function()
 				expect(message:find("RobloxRenderer%.spec")).to.be.ok()
 			end)
 		end)
+
+		it("should delete instances when reconciling to nil children", function()
+			local parent = Instance.new("Folder")
+			local key = "Some Key"
+
+			local element = createElement("Frame", {
+				Size = UDim2.new(1, 0, 1, 0),
+			}, {
+				child = createElement("Frame"),
+			})
+
+			local node = reconciler.createVirtualNode(element, parent, key)
+
+			RobloxRenderer.mountHostNode(reconciler, node)
+
+			expect(#parent:GetChildren()).to.equal(1)
+
+			local instance = parent:GetChildren()[1]
+			expect(#instance:GetChildren()).to.equal(1)
+
+			local newElement = createElement("Frame", {
+				Size = UDim2.new(0.5, 0, 0.5, 0),
+			})
+
+			RobloxRenderer.updateHostNode(reconciler, node, newElement)
+			expect(#instance:GetChildren()).to.equal(0)
+		end)
 	end)
 
 	describe("unmountHostNode", function()


### PR DESCRIPTION
Closes #209. In ea822f62ec11be3f979344cc34e03b81e48b0b53 we introduced an optimization in RobloxRenderer that avoids calling into the reconciler to update children if the element's children are `nil`. This introduced #209, where when updating a tree with an element that has `nil` children (not an empty table), the existing children are not unmounted.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] ~~Added/updated documentation~~