### PR TITLE
Make Fragment an Element

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Roact Changelog
 
 ## Unreleased Changes
+* Fixed a bug where fragments could not be used as child of a component. ([#214](https://github.com/Roblox/roact/pull/214))
 
 ## [1.1.0](https://github.com/Roblox/roact/releases/tag/v1.1.0) (June 3rd, 2019)
 * Fixed an issue where updating a host element with children to an element with `nil` children caused the old children to not be unmounted. ([#210](https://github.com/Roblox/roact/pull/210))

--- a/src/ElementKind.lua
+++ b/src/ElementKind.lua
@@ -19,6 +19,7 @@ local ElementKindInternal = {
 	Host = Symbol.named("Host"),
 	Function = Symbol.named("Function"),
 	Stateful = Symbol.named("Stateful"),
+	Fragment = Symbol.named("Fragment"),
 }
 
 function ElementKindInternal.of(value)

--- a/src/ElementUtils.lua
+++ b/src/ElementUtils.lua
@@ -40,10 +40,6 @@ ElementUtils.UseParentKey = Symbol.named("UseParentKey")
 function ElementUtils.iterateElements(elementOrElements)
 	local richType = Type.of(elementOrElements)
 
-	if richType == Type.Fragment then
-		return pairs(elementOrElements.elements)
-	end
-
 	-- Single child
 	if richType == Type.Element then
 		local called = false
@@ -91,10 +87,6 @@ function ElementUtils.getElementByKey(elements, hostKey)
 		end
 
 		return nil
-	end
-
-	if Type.of(elements) == Type.Fragment then
-		return elements.elements[hostKey]
 	end
 
 	if typeof(elements) == "table" then

--- a/src/ElementUtils.spec.lua
+++ b/src/ElementUtils.spec.lua
@@ -17,27 +17,6 @@ return function()
 			expect(iteratedKey).to.equal(nil)
 		end)
 
-		it("should iterate over fragments", function()
-			local children = createFragment({
-				a = createElement("TextLabel"),
-				b = createElement("TextLabel"),
-			})
-
-			local seenChildren = {}
-			local count = 0
-
-			for key, child in ElementUtils.iterateElements(children) do
-				expect(typeof(key)).to.equal("string")
-				expect(Type.of(child)).to.equal(Type.Element)
-				seenChildren[child] = key
-				count = count + 1
-			end
-
-			expect(count).to.equal(2)
-			expect(seenChildren[children.elements.a]).to.equal("a")
-			expect(seenChildren[children.elements.b]).to.equal("b")
-		end)
-
 		it("should iterate over tables", function()
 			local children = {
 				a = createElement("TextLabel"),
@@ -95,16 +74,6 @@ return function()
 			it("should return nil if the key is not UseParentKey", function()
 				expect(ElementUtils.getElementByKey(element, "test")).to.equal(nil)
 			end)
-		end)
-
-		it("should return the corresponding element from a fragment", function()
-			local children = createFragment({
-				a = createElement("TextLabel"),
-				b = createElement("TextLabel"),
-			})
-
-			expect(ElementUtils.getElementByKey(children, "a")).to.equal(children.elements.a)
-			expect(ElementUtils.getElementByKey(children, "b")).to.equal(children.elements.b)
 		end)
 
 		it("should return the corresponding element from a table", function()

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -712,24 +712,24 @@ return function()
 			local hostParent = Instance.new("Folder")
 			local hostKey = "Test"
 
-			local childAComponentSpy = createSpy(function(props)
+			local childAComponent = function(props)
 				return createElement("StringValue", {
 					Value = "A",
 				})
-			end)
-			local childBComponentSpy = createSpy(function(props)
+			end
+			local childBComponent = function(props)
 				return createElement("StringValue", {
 					Value = "B",
 				})
-			end)
+			end
 
 			local function parent(props)
 				return createElement("IntValue", {}, {
 					fragments_a = createFragment({
-						key = createElement(childAComponentSpy.value)
+						key = createElement(childAComponent)
 					}),
 					fragments_b = createFragment({
-						key = createElement(childBComponentSpy.value)
+						key = createElement(childBComponent)
 					}),
 				})
 			end
@@ -740,6 +740,14 @@ return function()
 			expect(#parentChildren).to.equal(2)
 			expect(parentChildren[1].ClassName).to.equal("StringValue")
 			expect(parentChildren[2].ClassName).to.equal("StringValue")
+
+			if parentChildren[1].Value ~= "A" then
+				expect(parentChildren[1].Value).to.equal("B")
+				expect(parentChildren[2].Value).to.equal("A")
+			else
+				expect(parentChildren[1].Value).to.equal("A")
+				expect(parentChildren[2].Value).to.equal("B")
+			end
 
 			reconciler.unmountVirtualNode(node)
 

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -694,7 +694,10 @@ return function()
 			local fragment = createFragment({
 				key = createElement("IntValue", {
 					Value = 1,
-				})
+				}),
+				key2 = createElement("IntValue", {
+					Value = 2,
+				}),
 			})
 
 			local node = reconciler.mountVirtualNode(fragment, hostParent, "test")
@@ -702,6 +705,10 @@ return function()
 			expect(hostParent:FindFirstChild("key")).to.be.ok()
 			expect(hostParent.key.ClassName).to.equal("IntValue")
 			expect(hostParent.key.Value).to.equal(1)
+
+			expect(hostParent:FindFirstChild("key2")).to.be.ok()
+			expect(hostParent.key2.ClassName).to.equal("IntValue")
+			expect(hostParent.key2.Value).to.equal(2)
 
 			reconciler.unmountVirtualNode(node)
 
@@ -712,24 +719,23 @@ return function()
 			local hostParent = Instance.new("Folder")
 			local hostKey = "Test"
 
-			local childAComponent = function(props)
-				return createElement("StringValue", {
-					Value = "A",
-				})
-			end
-			local childBComponent = function(props)
-				return createElement("StringValue", {
-					Value = "B",
-				})
-			end
-
 			local function parent(props)
 				return createElement("IntValue", {}, {
-					fragments_a = createFragment({
-						key = createElement(childAComponent)
+					fragmentA = createFragment({
+						key = createElement("StringValue", {
+							Value = "A",
+						}),
+						key2 = createElement("StringValue", {
+							Value = "B",
+						}),
 					}),
-					fragments_b = createFragment({
-						key = createElement(childBComponent)
+					fragmentB = createFragment({
+						key = createElement("StringValue", {
+							Value = "C",
+						}),
+						key2 = createElement("StringValue", {
+							Value = "D",
+						}),
 					}),
 				})
 			end
@@ -737,7 +743,7 @@ return function()
 			local node = reconciler.mountVirtualNode(createElement(parent), hostParent, hostKey)
 			local parentChildren = hostParent[hostKey]:GetChildren()
 
-			expect(#parentChildren).to.equal(2)
+			expect(#parentChildren).to.equal(4)
 
 			local childValues = {}
 
@@ -749,6 +755,8 @@ return function()
 			-- check if the StringValues have not collided
 			expect(childValues.A).to.equal(1)
 			expect(childValues.B).to.equal(1)
+			expect(childValues.C).to.equal(1)
+			expect(childValues.D).to.equal(1)
 
 			reconciler.unmountVirtualNode(node)
 
@@ -762,6 +770,9 @@ return function()
 				key = createFragment({
 					TheValue = createElement("IntValue", {
 						Value = 1,
+					}),
+					TheOtherValue = createElement("IntValue", {
+						Value = 2,
 					})
 				})
 			})
@@ -771,6 +782,10 @@ return function()
 			expect(hostParent:FindFirstChild("TheValue")).to.be.ok()
 			expect(hostParent.TheValue.ClassName).to.equal("IntValue")
 			expect(hostParent.TheValue.Value).to.equal(1)
+
+			expect(hostParent:FindFirstChild("TheOtherValue")).to.be.ok()
+			expect(hostParent.TheOtherValue.ClassName).to.equal("IntValue")
+			expect(hostParent.TheOtherValue.Value).to.equal(2)
 
 			reconciler.unmountVirtualNode(node)
 

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -767,6 +767,18 @@ return function()
 
 			expect(#hostParent:GetChildren()).to.equal(0)
 		end)
+
+		it("should not add any instances if the fragment is empty", function()
+			local hostParent = Instance.new("Folder")
+
+			local node = reconciler.mountVirtualNode(createFragment({}), hostParent, "test")
+
+			expect(#hostParent:GetChildren()).to.equal(0)
+
+			reconciler.unmountVirtualNode(node)
+
+			expect(#hostParent:GetChildren()).to.equal(0)
+		end)
 	end)
 
 	describe("Context", function()

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -738,16 +738,17 @@ return function()
 			local parentChildren = hostParent[hostKey]:GetChildren()
 
 			expect(#parentChildren).to.equal(2)
-			expect(parentChildren[1].ClassName).to.equal("StringValue")
-			expect(parentChildren[2].ClassName).to.equal("StringValue")
 
-			if parentChildren[1].Value ~= "A" then
-				expect(parentChildren[1].Value).to.equal("B")
-				expect(parentChildren[2].Value).to.equal("A")
-			else
-				expect(parentChildren[1].Value).to.equal("A")
-				expect(parentChildren[2].Value).to.equal("B")
+			local childValues = {}
+
+			for _, child in pairs(parentChildren) do
+				expect(child.ClassName).to.equal("StringValue")
+				childValues[child.Value] = 1 + (childValues[child.Value] or 0)
 			end
+
+			-- check if the StringValues have not collided
+			expect(childValues.A).to.equal(1)
+			expect(childValues.B).to.equal(1)
 
 			reconciler.unmountVirtualNode(node)
 

--- a/src/Type.lua
+++ b/src/Type.lua
@@ -22,7 +22,6 @@ end
 
 addType("Binding")
 addType("Element")
-addType("Fragment")
 addType("HostChangeEvent")
 addType("HostEvent")
 addType("StatefulComponentClass")

--- a/src/createFragment.lua
+++ b/src/createFragment.lua
@@ -1,8 +1,10 @@
+local ElementKind = require(script.Parent.ElementKind)
 local Type = require(script.Parent.Type)
 
 local function createFragment(elements)
 	return {
-		[Type] = Type.Fragment,
+		[Type] = Type.Element,
+		[ElementKind] = ElementKind.Fragment,
 		elements = elements,
 	}
 end

--- a/src/createFragment.spec.lua
+++ b/src/createFragment.spec.lua
@@ -1,0 +1,21 @@
+return function()
+	local ElementKind = require(script.Parent.ElementKind)
+	local Type = require(script.Parent.Type)
+
+	local createFragment = require(script.Parent.createFragment)
+
+	it("should create new primitive elements", function()
+		local fragment = createFragment({})
+
+		expect(fragment).to.be.ok()
+		expect(Type.of(fragment)).to.equal(Type.Element)
+		expect(ElementKind.of(fragment)).to.equal(ElementKind.Fragment)
+	end)
+
+	it("should accept children", function()
+		local subFragment = createFragment({})
+		local fragment = createFragment({key = subFragment})
+
+		expect(fragment.elements.key).to.equal(subFragment)
+	end)
+end

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -138,6 +138,10 @@ local function createReconciler(renderer)
 			for _, childNode in pairs(virtualNode.children) do
 				unmountVirtualNode(childNode)
 			end
+		elseif kind == ElementKind.Fragment then
+			for _, childNode in pairs(virtualNode.children) do
+				unmountVirtualNode(childNode)
+			end
 		else
 			error(("Unknown ElementKind %q"):format(tostring(kind), 2))
 		end
@@ -166,6 +170,12 @@ local function createReconciler(renderer)
 		local children = newElement.props[Children]
 
 		updateVirtualNodeWithChildren(virtualNode, targetHostParent, children)
+
+		return virtualNode
+	end
+
+	local function updateFragmentVirtualNode(virtualNode, newElement)
+		updateVirtualNodeWithChildren(virtualNode, virtualNode.hostParent, newElement.elements)
 
 		return virtualNode
 	end
@@ -219,6 +229,8 @@ local function createReconciler(renderer)
 			shouldContinueUpdate = virtualNode.instance:__update(newElement, newState)
 		elseif kind == ElementKind.Portal then
 			virtualNode = updatePortalVirtualNode(virtualNode, newElement)
+		elseif kind == ElementKind.Fragment then
+			virtualNode = updateFragmentVirtualNode(virtualNode, newElement)
 		else
 			error(("Unknown ElementKind %q"):format(tostring(kind), 2))
 		end
@@ -283,6 +295,13 @@ local function createReconciler(renderer)
 		updateVirtualNodeWithChildren(virtualNode, targetHostParent, children)
 	end
 
+	local function mountFragmentVirtualNode(virtualNode)
+		local element = virtualNode.currentElement
+		local children = element.elements
+
+		updateVirtualNodeWithChildren(virtualNode, virtualNode.hostParent, children)
+	end
+
 	--[[
 		Constructs a new virtual node and mounts it, but does not place it into
 		the tree.
@@ -317,6 +336,8 @@ local function createReconciler(renderer)
 			element.component:__mount(reconciler, virtualNode)
 		elseif kind == ElementKind.Portal then
 			mountPortalVirtualNode(virtualNode)
+		elseif kind == ElementKind.Fragment then
+			mountFragmentVirtualNode(virtualNode)
 		else
 			error(("Unknown ElementKind %q"):format(tostring(kind), 2))
 		end

--- a/src/createReconciler.spec.lua
+++ b/src/createReconciler.spec.lua
@@ -297,25 +297,30 @@ return function()
 			expect(ElementKind.of(node.currentElement)).to.equal(ElementKind.Fragment)
 		end)
 
-		it("should mount fragments children", function()
-			local childComponentSpy = createSpy(function(props)
-				return nil
-			end)
-			local fragment = createFragment({
-				key = createElement(childComponentSpy.value, {})
-			})
-			local node = noopReconciler.mountVirtualNode(fragment, nil, "test")
-
-			expect(childComponentSpy.callCount).to.equal(1)
-			expect(node.children.key).to.be.ok()
-		end)
-
 		it("should mount an empty fragment", function()
 			local emptyFragment = createFragment({})
 			local node = noopReconciler.mountVirtualNode(emptyFragment, nil, "test")
 
 			expect(node).to.be.ok()
 			expect(next(node.children)).to.never.be.ok()
+		end)
+
+		it("should mount all fragment's children", function()
+			local childComponentSpy = createSpy(function(props)
+				return nil
+			end)
+			local elements = {}
+			local totalElements = 5
+
+			for i=1, totalElements do
+				elements["key"..tostring(i)] = createElement(childComponentSpy.value, {})
+			end
+
+			local fragments = createFragment(elements)
+			local node = noopReconciler.mountVirtualNode(fragments, nil, "test")
+
+			expect(node).to.be.ok()
+			expect(childComponentSpy.callCount).to.equal(totalElements)
 		end)
 	end)
 end

--- a/src/createReconciler.spec.lua
+++ b/src/createReconciler.spec.lua
@@ -5,6 +5,7 @@ return function()
 	local createSpy = require(script.Parent.createSpy)
 	local NoopRenderer = require(script.Parent.NoopRenderer)
 	local Type = require(script.Parent.Type)
+	local ElementKind = require(script.Parent.ElementKind)
 
 	local createReconciler = require(script.Parent.createReconciler)
 
@@ -288,7 +289,15 @@ return function()
 	end)
 
 	describe("Fragments", function()
-		it("should mount fragments child", function()
+		it("should mount fragments", function()
+			local fragment = createFragment({})
+			local node = noopReconciler.mountVirtualNode(fragment, nil, "test")
+
+			expect(node).to.be.ok()
+			expect(ElementKind.of(node.currentElement)).to.equal(ElementKind.Fragment)
+		end)
+
+		it("should mount fragments children", function()
 			local childComponentSpy = createSpy(function(props)
 				return nil
 			end)
@@ -298,10 +307,7 @@ return function()
 			local node = noopReconciler.mountVirtualNode(fragment, nil, "test")
 
 			expect(childComponentSpy.callCount).to.equal(1)
-
-			node = noopReconciler.updateVirtualNode(node, true)
-
-			expect(node).to.equal(nil)
+			expect(node.children.key).to.be.ok()
 		end)
 	end)
 end

--- a/src/createReconciler.spec.lua
+++ b/src/createReconciler.spec.lua
@@ -309,5 +309,13 @@ return function()
 			expect(childComponentSpy.callCount).to.equal(1)
 			expect(node.children.key).to.be.ok()
 		end)
+
+		it("should mount an empty fragment", function()
+			local emptyFragment = createFragment({})
+			local node = noopReconciler.mountVirtualNode(emptyFragment, nil, "test")
+
+			expect(node).to.be.ok()
+			expect(next(node.children)).to.never.be.ok()
+		end)
 	end)
 end

--- a/src/createReconciler.spec.lua
+++ b/src/createReconciler.spec.lua
@@ -47,7 +47,7 @@ return function()
 		end)
 	end)
 
-	describe("elements and fragments", function()
+	describe("invalid elements", function()
 		it("should throw errors when attempting to mount invalid elements", function()
 			-- These function components return values with incorrect types
 			local returnsString = function()
@@ -284,6 +284,24 @@ return function()
 			expect(parentComponentSpy.callCount).to.equal(1)
 			expect(childAComponentSpy.callCount).to.equal(1)
 			expect(childBComponentSpy.callCount).to.equal(1)
+		end)
+	end)
+
+	describe("Fragments", function()
+		it("should mount fragments child", function()
+			local childComponentSpy = createSpy(function(props)
+				return nil
+			end)
+			local fragment = createFragment({
+				key = createElement(childComponentSpy.value, {})
+			})
+			local node = noopReconciler.mountVirtualNode(fragment, nil, "test")
+
+			expect(childComponentSpy.callCount).to.equal(1)
+
+			node = noopReconciler.updateVirtualNode(node, true)
+
+			expect(node).to.equal(nil)
 		end)
 	end)
 end


### PR DESCRIPTION
Closes #205

Fragments can now be used directly as children of a component:
```lua
local function component()
    return Roact.createElement("Frame", {}, {
        fragments = Roact.createFragment({
            A = Roact.createElement("Frame", {}, {})
        })
    })
end
```
Turning Fragments into Elements make them have their own virtual node, so they can be reconciled as any other nodes.

I'm not so sure about how to write good tests for that, let me know what's the best way (not sure where to assert exactly).

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [ ] Added/updated documentation