### PR TITLE
Reorder render result checks and fix bug

### DIFF
--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -101,7 +101,6 @@ local function createReconciler(renderer)
 	end
 
 	local function updateVirtualNodeWithRenderResult(virtualNode, hostParent, renderResult)
-		-- TODO: Consider reordering checks (https://github.com/Roblox/roact/issues/200)
 		if Type.of(renderResult) == Type.Element
 			or renderResult == nil
 			or typeof(renderResult) == "boolean"

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -102,10 +102,9 @@ local function createReconciler(renderer)
 
 	local function updateVirtualNodeWithRenderResult(virtualNode, hostParent, renderResult)
 		-- TODO: Consider reordering checks (https://github.com/Roblox/roact/issues/200)
-		if renderResult == nil
+		if Type.of(renderResult) == Type.Element
+			or renderResult == nil
 			or typeof(renderResult) == "boolean"
-			or Type.of(renderResult) == Type.Element
-			or Type.of(renderResult) == Type.Fragment
 		then
 			updateChildren(virtualNode, hostParent, renderResult)
 		else


### PR DESCRIPTION
Since Fragment is an ElementKind and no longer a Type the check should have been removed in my last pull request.

Let me know if the order `Type.Element`, `nil` and `boolean` is what's best.

Closes #200.

*Put your pull request body here!*

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation