### PR TITLE
Implement Roact.Style

### DIFF
--- a/src/PropMarkers/Style.lua
+++ b/src/PropMarkers/Style.lua
@@ -1,0 +1,5 @@
+local Symbol = require(script.Parent.Parent.Symbol)
+
+local Style = Symbol.named("Style")
+
+return Style

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -11,6 +11,7 @@ return function()
 	local GlobalConfig = require(script.Parent.GlobalConfig)
 	local Portal = require(script.Parent.Portal)
 	local Ref = require(script.Parent.PropMarkers.Ref)
+	local Style = require(script.Parent.PropMarkers.Style)
 
 	local RobloxRenderer = require(script.Parent.RobloxRenderer)
 
@@ -871,6 +872,28 @@ return function()
 			assertDeepEqual(capturedContext, {
 				foo = "bar"
 			})
+		end)
+	end)
+
+	describe("Style", function()
+		it("should do style things", function()
+			local BetterDefaultFolder = {
+				BackgroundColor3 = Color3.new(1, 1, 1),
+				BorderSizePixel = 0,
+			}
+
+			local element = createElement("Frame", {
+				[Style] = BetterDefaultFolder,
+				BackgroundColor3 = Color3.new(0, 0, 0),
+			})
+			local hostParent = Instance.new("Folder")
+			local hostKey = "Child"
+			reconciler.mountVirtualNode(element, hostParent, hostKey)
+
+			local instance = hostParent[hostKey]
+
+			expect(instance.BorderSizePixel).to.equal(0)
+			expect(instance.BackgroundColor3).to.equal(Color3.new(0, 0, 0))
 		end)
 	end)
 end

--- a/src/init.lua
+++ b/src/init.lua
@@ -28,6 +28,7 @@ local Roact = strict {
 	Children = require(script.PropMarkers.Children),
 	Event = require(script.PropMarkers.Event),
 	Ref = require(script.PropMarkers.Ref),
+	Style = require(script.PropMarkers.Style),
 
 	mount = robloxReconciler.mountVirtualTree,
 	unmount = robloxReconciler.unmountVirtualTree,

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -25,6 +25,7 @@ return function()
 			Children = true,
 			Event = true,
 			Change = true,
+			Style = true,
 			Ref = true,
 			None = true,
 			UNSTABLE = true,


### PR DESCRIPTION
Closes #192.

This is a rough PR trying to implement the `Roact.Style` prop, which behaves similarly to how CSS modules work in React on the web.

In short:

```lua
local BetterDefaultFrame = {
	BackgroundColor3 = Color3.new(1, 1, 1),
	BorderSizePixel = 0,
}

Roact.createElement("Frame", {
	[Roact.Style] = BetterDefaultFrame,
	BackgroundColor3 = Color3.new(0, 0, 0),
})
```

This element describes a `Frame` whose resulting `BorderSizePixel` is 0 and whose `BackgroundColor3` is `(0, 0, 0)`. Props take precedence over style.

## Big gains
* **Readability**: This also helps reduce the number of unimportant boilerplate props in our render functions, making the hierarchy much more obvious.
* **Performance**: We should be able to optimize heavily for the case where the `Style` prop does not change. Changes to `Style` should be infrequent and the table itself should be completely static or at least memoized.
    * This could be a good way to improve the performance of Roact and help its reputation. 

## Intended uses
* Define a slate of better default instances. `Frame` feels like it should have a transparent background and no border, but specifying that prop everywhere is tedious.
* Applying themes uniformly. Components of the same type often map theme values onto the same props. It'd be useful to re-use those mappings across many components without needing to add extra layers of component goop.

## Future work
* Set `Roact.Style` to a binding or keys in the style table to bindings?
* Built-in functions to merge and memoize operations over styles
    * @MisterUncloaked mentioned parameterized styles for components that are mostly similar
* We might be able to store component-style pairs and keep around a template instance that we can clone. This would let us avoid needing to traverse the style table during mounting and might be an easy-ish performance win.
    * This wouldn't be compatible with bindings inside the style table, most likely.
    * Cache eviction, if we do it at all, will be hairy.

## Checklist before submitting
* [ ] Check app code to see how many props can be moved to `Roact.Style`
* [ ] Intended interactions for user components to deal with `Roact.Style` keys.
    * As-is, components will write `props.Size or props[Roact.Style] and props[Roact.Style].Size`
* [ ] Rewrite with a feature flag?
* [ ] Do more robust implementation with tests
* [ ] Measure performance impact
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation