### PR TITLE
Fix benchmarks

### DIFF
--- a/benchmarks.project.json
+++ b/benchmarks.project.json
@@ -1,5 +1,5 @@
 {
-  "name": "Roact Test Place",
+  "name": "Roact Benchmarks Place",
   "tree": {
     "$className": "DataModel",
 
@@ -8,30 +8,14 @@
 
       "Roact": {
         "$path": "src"
-      },
-
-      "TestEZ": {
-        "$path": "modules/testez/lib"
-      }
-    },
-
-    "StarterPlayer": {
-      "$className": "StarterPlayer",
-
-      "StarterPlayerScripts": {
-        "$className": "StarterPlayerScripts",
-
-        "RoactExamples": {
-          "$path": "examples"
-        }
       }
     },
 
     "ServerScriptService": {
       "$className": "ServerScriptService",
 
-      "RoactTests": {
-        "$path": "bin/run-tests.server.lua"
+      "RoactBenchmark": {
+        "$path": "benchmarks"
       }
     },
 

--- a/benchmarks/hello.bench.lua
+++ b/benchmarks/hello.bench.lua
@@ -1,4 +1,5 @@
-local Roact = require(script.Parent.Parent.Roact)
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Roact = require(ReplicatedStorage.Roact)
 
 return {
 	iterations = 100000,

--- a/benchmarks/update.bench.lua
+++ b/benchmarks/update.bench.lua
@@ -1,4 +1,5 @@
-local Roact = require(script.Parent.Parent.Roact)
+local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local Roact = require(ReplicatedStorage.Roact)
 
 local tree
 

--- a/bin/bench.lua
+++ b/bin/bench.lua
@@ -26,8 +26,12 @@ for _, module in ipairs(LOAD_MODULES) do
 	container.Parent = root
 end
 
-local benchmarks = habitat:loadFromFs("benchmarks")
-benchmarks.Name = "Benchmark"
-benchmarks.Parent = root
+local runBenchMarks = habitat:loadFromFs("benchmarks/init.server.lua")
+runBenchMarks.Name = "RoactBenchmark"
+runBenchMarks.Parent = root
 
-habitat:require(benchmarks)
+local benchmarks = habitat:loadFromFs("benchmarks")
+benchmarks.Name = "Benchmarks"
+benchmarks.Parent = runBenchMarks
+
+habitat:require(runBenchMarks)


### PR DESCRIPTION
## Problem

Benchmarks could neither be run from the command line nor from the place generated from place.project.json

1) Habitat:loadFromFs does not know to create a module script when loading a folder with an init.server.lua in it
2) Each benchmark assumed it lived relative to Roact which is not necessarily true - in place.project.json the benchmarks live in ServerScriptService so that that are run automatically

## Solution
1) Load the init file directly so that we get a module script to require, and not a folder
2) Always look to replicated storage when looking for Roact in the context of a benchmark

## Testing

Observed that benchmarks ran via

lua bin/bench.lua
rojo build place.project.json -o RoactTestPlace.rbxlx --> open and click play