### PR TITLE
Fix tests that depend on specific config values to use the "scoped" feature

### DIFF
--- a/src/Binding.spec.lua
+++ b/src/Binding.spec.lua
@@ -1,6 +1,7 @@
 return function()
 	local createSpy = require(script.Parent.createSpy)
 	local Type = require(script.Parent.Type)
+	local GlobalConfig = require(script.Parent.GlobalConfig)
 
 	local Binding = require(script.Parent.Binding)
 
@@ -241,20 +242,28 @@ return function()
 		end)
 
 		it("should throw when a non-table value is passed", function()
-			expect(function()
-				Binding.join("hi")
-			end).to.throw()
+			GlobalConfig.scoped({
+				typeChecks = true,
+			}, function()
+				expect(function()
+					Binding.join("hi")
+				end).to.throw()
+			end)
 		end)
 
 		it("should throw when a non-binding value is passed via table", function()
-			expect(function()
-				local binding = Binding.create(123)
+			GlobalConfig.scoped({
+				typeChecks = true,
+			}, function()
+				expect(function()
+					local binding = Binding.create(123)
 
-				Binding.join({
-					binding,
-					"abcde",
-				})
-			end).to.throw()
+					Binding.join({
+						binding,
+						"abcde",
+					})
+				end).to.throw()
+			end)
 		end)
 	end)
 end


### PR DESCRIPTION
Fixes a test that may fail if not run with the `bin/spec.lua` test runner. The tests depend on having the `typeChecks` global config value set to true, but did not express this dependency as written.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~
* [x] Added/updated relevant tests
* ~~Added/updated documentation~~