### PR TITLE
Add Type Checking API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased Changes
 * Improved the error message when an invalid changed hook name is used. ([#216](https://github.com/Roblox/roact/pull/216))
 * Fixed a bug where fragments could not be used as children of an element or another fragment. ([#214](https://github.com/Roblox/roact/pull/214))
+* Added Roact.Type and Roact.typeOf for Roact object type checking. ([#230](https://github.com/Roblox/roact/pull/230))
 
 ## [1.1.0](https://github.com/Roblox/roact/releases/tag/v1.1.0) (June 3rd, 2019)
 * Fixed an issue where updating a host element with children to an element with `nil` children caused the old children to not be unmounted. ([#210](https://github.com/Roblox/roact/pull/210))

--- a/docs/advanced/type-checking.md
+++ b/docs/advanced/type-checking.md
@@ -1,0 +1,70 @@
+In certain situations, such as when building highly reusable and customizable components, props may be composed of Roact objects, such as an element or a component class. To facilitate safer development for these kinds of situations, Roact exposes a type enumeration and a type checking function.
+
+## Without Type Checking
+
+Suppose we want to write a Header component with a prop for the title child element:
+```lua
+local Header = Component:extend("Header")
+function Header:render()
+	local titleClass = props.titleClass
+	return Roact.createElement("Frame", {
+		-- Props for Frame...
+	}, {
+		Title = Roact.createElement(titleViewClass, {
+			-- Props for Title...
+		})
+	})
+end
+```
+
+Now suppose we want to validate that a titleClass is actually a class using [validateProps](../../api-reference/#validateprops). Unfortunately, the best we can do is inspect Header to see if it contains characteristics of a Component class:
+```lua
+local Header = Component:extend("Header")
+Header.validateProps = function()
+	local titleClass = props.titleClass
+	if titleClass.render then
+		return true
+	end
+	return false, tostring(Header) .. " prop titleClass cannot render"
+end
+```
+
+## With Type Checking
+
+With type checking, we can be certain we have a Component class:
+```lua
+Header.validateProps = function()
+	local titleClass = props.titleClass
+	if Roact.typeOf(titleClass) == Roact.Type.StatefulComponentClass then
+		return true
+	end
+	return false, tostring(Header) .. " prop titleClass is not a component class"
+end
+```
+
+We can even provide props which can be of multiple different Roact object types to give the consumer more flexibility:
+```lua
+local Header = Component:extend("Header")
+Header.validateProps = function()
+	local title = props.title -- Type.Element | Type.StatefulComponentClass
+	local type = Roact.typeOf(titleClass)
+	local isElement = type == Roact.Type.Element
+	local isClass = type == Roact.Type.StatefulComponentClass
+	if isElement or isClass then
+		return true
+	end
+	return false, tostring(Header) .. " prop title must be a class or element"
+end
+function Header:render()
+	local title = props.title
+	local isElement = Roact.typeOf(title) == Roact.Type.Element
+	local isClass = type == Roact.Type.StatefulComponentClass
+	return Roact.createElement("Frame", {
+		-- Props for Frame...
+	}, {
+		Title = isElement and title or isClass and Roact.createElement(title, {
+			-- Props for Title...
+		})
+	})
+end
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -23,6 +23,7 @@ nav:
     - Portals: advanced/portals.md
     - Bindings and Refs: advanced/bindings-and-refs.md
     - Context: advanced/context.md
+    - Type Checking: advanced/type-checking.md
   - Performance Optimization:
     - Overview: performance/overview.md
     - Reduce Reconcilation: performance/reduce-reconciliation.md

--- a/src/Type.lua
+++ b/src/Type.lua
@@ -15,9 +15,12 @@ local strict = require(script.Parent.strict)
 local Type = newproxy(true)
 
 local TypeInternal = {}
+local TypeNames = {}
 
 local function addType(name)
-	TypeInternal[name] = Symbol.named("Roact" .. name)
+	local symbol = Symbol.named("Roact" .. name)
+	TypeNames[symbol] = name
+	TypeInternal[name] = symbol
 end
 
 addType("Binding")
@@ -37,6 +40,14 @@ function TypeInternal.of(value)
 	return value[Type]
 end
 
+function TypeInternal.nameOf(type)
+	if typeof(type) ~= "userdata" then
+		return nil
+	end
+
+	return TypeNames[type]
+end
+
 getmetatable(Type).__index = TypeInternal
 
 getmetatable(Type).__tostring = function()
@@ -44,5 +55,6 @@ getmetatable(Type).__tostring = function()
 end
 
 strict(TypeInternal, "Type")
+strict(TypeNames, "TypeNames")
 
 return Type

--- a/src/Type.spec.lua
+++ b/src/Type.spec.lua
@@ -20,5 +20,9 @@ return function()
 
 			expect(Type.of(test)).to.equal(Type.Element)
 		end)
+
+		it("should return a type's name", function()
+			expect(Type.nameOf(Type.Element)).to.equal("Element")
+		end)
 	end)
 end

--- a/src/TypeMirror.lua
+++ b/src/TypeMirror.lua
@@ -1,0 +1,48 @@
+local Type = require(script.Parent.Type)
+local Symbol = require(script.Parent.Symbol)
+local strict = require(script.Parent.strict)
+
+local ALLOWED_TYPES = {
+	Type.Binding,
+	Type.Element,
+	Type.HostChangeEvent,
+	Type.HostEvent,
+	Type.StatefulComponentClass,
+	Type.StatefulComponentInstance,
+	Type.VirtualTree
+}
+
+local MirroredType = newproxy(true)
+local MirroredTypeInternal = {}
+for _, type in ipairs(ALLOWED_TYPES) do
+	local name = Type.nameOf(type)
+	MirroredTypeInternal[name] = Symbol.named("Roact" .. name)
+end
+
+getmetatable(MirroredType).__index = MirroredTypeInternal
+getmetatable(MirroredType).__tostring = function()
+	return "RoactType"
+end
+
+strict(MirroredTypeInternal, "Type")
+
+local Mirror = newproxy(true)
+local MirrorInternal = {
+	Type = MirroredType,
+	typeOf = function(value)
+		local name = Type.nameOf(Type.of(value))
+		if not name then
+			return nil
+		end
+		return MirroredTypeInternal[name]
+	end,
+}
+
+getmetatable(Mirror).__index = MirrorInternal
+getmetatable(Mirror).__tostring = function()
+	return "TypeMirror"
+end
+
+strict(MirrorInternal, "TypeMirror")
+
+return Mirror

--- a/src/TypeMirror.lua
+++ b/src/TypeMirror.lua
@@ -1,3 +1,13 @@
+--[[
+	Mirrors a subset of values from Type.lua for external use, allowing
+	type checking on Roact objects without exposing internal Type symbols
+
+	TypeMirror: {
+		Type: Roact.Type,
+		typeof: function(value: table) -> Roact.Type | nil
+	}
+]]
+
 local Type = require(script.Parent.Type)
 local Symbol = require(script.Parent.Symbol)
 local strict = require(script.Parent.strict)

--- a/src/TypeMirror.spec.lua
+++ b/src/TypeMirror.spec.lua
@@ -1,0 +1,64 @@
+return function()
+	local Type = require(script.Parent.Type)
+	local Mirror = require(script.Parent.TypeMirror)
+	local allowedTypes = {
+		Type.Binding,
+		Type.Element,
+		Type.HostChangeEvent,
+		Type.HostEvent,
+		Type.StatefulComponentClass,
+		Type.StatefulComponentInstance,
+		Type.VirtualTree
+	}
+
+	describe("Type", function()
+		it("should return a mirror of an internal type", function()
+			local name = Type.nameOf(Type.Element)
+			local mirroredType = Mirror.Type[name]
+			expect(mirroredType).to.equal(Mirror.Type.Element)
+		end)
+
+		it("should not return the actual internal type", function()
+			local name = Type.nameOf(Type.Element)
+			local mirroredType = Mirror.Type[name]
+			expect(mirroredType).to.never.equal(Type.Element)
+		end)
+
+		it("should include all allowed types", function()
+			for _, type in ipairs(allowedTypes) do
+				local name = Type.nameOf(type)
+				local mirroredType = Mirror.Type[name]
+				expect(mirroredType).to.be.ok()
+			end
+		end)
+
+		it("should not include any other types", function()
+			local name = Type.nameOf(Type.VirtualNode)
+			local success = pcall(function()
+				local _ = Mirror.Type[name]
+			end)
+			expect(success).to.equal(false)
+		end)
+	end)
+
+	describe("typeOf", function()
+		it("should return nil if the value is not a table", function()
+			expect(Mirror.typeOf(1)).to.equal(nil)
+			expect(Mirror.typeOf(true)).to.equal(nil)
+			expect(Mirror.typeOf("test")).to.equal(nil)
+			expect(Mirror.typeOf(print)).to.equal(nil)
+		end)
+
+		it("should return nil if the table has no type", function()
+			expect(Mirror.typeOf({})).to.equal(nil)
+		end)
+
+		it("should return the assigned type", function()
+			local test = {
+				[Type] = Type.Element
+			}
+
+			expect(Mirror.typeOf(test)).to.equal(Mirror.Type.Element)
+		end)
+	end)
+end

--- a/src/init.lua
+++ b/src/init.lua
@@ -8,6 +8,7 @@ local createReconcilerCompat = require(script.createReconcilerCompat)
 local RobloxRenderer = require(script.RobloxRenderer)
 local strict = require(script.strict)
 local Binding = require(script.Binding)
+local TypeMirror = require(script.TypeMirror)
 
 local robloxReconciler = createReconciler(RobloxRenderer)
 local reconcilerCompat = createReconcilerCompat(robloxReconciler)
@@ -36,6 +37,9 @@ local Roact = strict {
 	reify = reconcilerCompat.reify,
 	teardown = reconcilerCompat.teardown,
 	reconcile = reconcilerCompat.reconcile,
+
+	typeOf = TypeMirror.typeOf,
+	Type = TypeMirror.Type,
 
 	setGlobalConfig = GlobalConfig.set,
 

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -13,6 +13,7 @@ return function()
 			update = "function",
 			oneChild = "function",
 			setGlobalConfig = "function",
+			typeOf = "function",
 
 			-- These functions are deprecated and throw warnings!
 			reify = "function",
@@ -26,6 +27,7 @@ return function()
 			Event = true,
 			Change = true,
 			Ref = true,
+			Type = true,
 			None = true,
 			UNSTABLE = true,
 		}


### PR DESCRIPTION
Closes https://github.com/Roblox/roact/issues/227

Added a public API for type checking in Roact

- Added nameOf function to Type to lookup the string name for any Type
- Added TypeMirror module which exposes a subset of types in Type without exposing the internal Roact symbols
- Added Roact.Type and Roact.typeOf to expose a type checking API for external use

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] Added/updated documentation