### PR TITLE
Add scripts to generate release models

### DIFF
--- a/bin/build-release.sh
+++ b/bin/build-release.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+# Generates a release build of Roact with tests stripped.
+#
+# Usage from repo root:
+# ./bin/build-release.sh
+
+set -ev
+
+rojo build -o Roact.rbxmx
+remodel bin/strip-tests.lua Roact.rbxmx

--- a/bin/strip-tests.lua
+++ b/bin/strip-tests.lua
@@ -1,0 +1,23 @@
+-- This script is meant for execution with Remodel:
+-- https://github.com/rojo-rbx/remodel
+--
+-- Usage:
+-- remodel bin/strip-tests.lua my-model.rbxmx
+
+local inputFile = ...
+
+local function stripSpecs(container)
+	if container.Name:find("%.spec") ~= nil then
+		container.Parent = nil
+	else
+		for _, child in ipairs(container:GetChildren()) do
+			stripSpecs(child)
+		end
+	end
+end
+
+local model = remodel.readModelFile(inputFile)[1]
+
+stripSpecs(model)
+
+remodel.writeModelFile(model, inputFile)


### PR DESCRIPTION
This adds a script or two to the `bin` folder to help us generate good release models.

We can use this in the future as part of our CI flow, but in the mean time, it should serve as light automation to generate builds at any point that can be dragged into Roblox Studio.

We should wait for `rbxm` support to be ironed out in Remodel before merging this, and switch everything over to using the binary model format instead.