### PR TITLE
New internal Context API

### DIFF
--- a/src/Component.lua
+++ b/src/Component.lua
@@ -205,7 +205,7 @@ function Component:__getContext(key)
 	end
 
 	local virtualNode = self[InternalData].virtualNode
-	local context = virtualNode.context or virtualNode.inheritedContext
+	local context = virtualNode.context
 
 	return context[key]
 end
@@ -218,10 +218,18 @@ function Component:__addContext(key, value)
 	if config.internalTypeChecks then
 		internalAssert(Type.of(self) == Type.StatefulComponentInstance, "Invalid use of `__addContext`")
 	end
-
-	local existing = self:__getContext()
 	local virtualNode = self[InternalData].virtualNode
 
+	-- If we don't already have the component's original, unmodified context
+	-- stored in the virtual node, store it now so we can restore it if the node
+	-- gets replaced by a different component
+	if virtualNode.originalContext == nil then
+		virtualNode.originalContext = virtualNode.context
+	end
+
+	-- Build a new context table, on top of the existing one, and apply it to
+	-- our node
+	local existing = self:__getContext()
 	virtualNode.context = assign({}, existing, { key = value })
 end
 

--- a/src/Component.lua
+++ b/src/Component.lua
@@ -197,7 +197,8 @@ function Component:render()
 end
 
 --[[
-	Retrieves the context object corresponding to the given key
+	Retrieves the context value corresponding to the given key. Can return nil
+	if a requested context key is not present
 ]]
 function Component:__getContext(key)
 	if config.internalTypeChecks then
@@ -212,8 +213,8 @@ function Component:__getContext(key)
 end
 
 --[[
-	Adds new context property to this component's context table (which will be
-	passed down to child components)
+	Adds a new context entry to this component's context table (which will be
+	passed down to child components).
 ]]
 function Component:__addContext(key, value)
 	if config.internalTypeChecks then
@@ -221,15 +222,16 @@ function Component:__addContext(key, value)
 	end
 	local virtualNode = self[InternalData].virtualNode
 
-	-- If we don't already have the component's original, unmodified context
-	-- stored in the virtual node, store it now so we can restore it if the node
-	-- gets replaced by a different component
+	-- Make sure we store a reference to the component's original, unmodified
+	-- context the virtual node. In the reconciler, we'll restore the original
+	-- context if we need to replace the node (this happens when a node gets
+	-- re-rendered as a different component)
 	if virtualNode.originalContext == nil then
 		virtualNode.originalContext = virtualNode.context
 	end
 
-	-- Build a new context table, on top of the existing one, and apply it to
-	-- our node
+	-- Build a new context table on top of the existing one, then apply it to
+	-- our virtualNode
 	local existing = virtualNode.context
 	virtualNode.context = assign({}, existing, { [key] = value })
 end

--- a/src/Component.lua
+++ b/src/Component.lua
@@ -202,6 +202,7 @@ end
 function Component:__getContext(key)
 	if config.internalTypeChecks then
 		internalAssert(Type.of(self) == Type.StatefulComponentInstance, "Invalid use of `__getContext`")
+		internalAssert(key ~= nil, "Context key cannot be nil")
 	end
 
 	local virtualNode = self[InternalData].virtualNode
@@ -211,7 +212,7 @@ function Component:__getContext(key)
 end
 
 --[[
-	Adds new context property to this component's context map (which will be
+	Adds new context property to this component's context table (which will be
 	passed down to child components)
 ]]
 function Component:__addContext(key, value)
@@ -229,8 +230,8 @@ function Component:__addContext(key, value)
 
 	-- Build a new context table, on top of the existing one, and apply it to
 	-- our node
-	local existing = self:__getContext()
-	virtualNode.context = assign({}, existing, { key = value })
+	local existing = virtualNode.context
+	virtualNode.context = assign({}, existing, { [key] = value })
 end
 
 --[[

--- a/src/Component.lua
+++ b/src/Component.lua
@@ -273,7 +273,7 @@ function Component:__mount(reconciler, virtualNode)
 
 	instance.props = props
 
-	local newContext = assign({}, virtualNode.context)
+	local newContext = assign({}, virtualNode.legacyContext)
 	instance._context = newContext
 
 	instance.state = assign({}, instance:__getDerivedState(instance.props, {}))
@@ -284,7 +284,7 @@ function Component:__mount(reconciler, virtualNode)
 	end
 
 	-- It's possible for init() to redefine _context!
-	virtualNode.context = instance._context
+	virtualNode.legacyContext = instance._context
 
 	internalData.lifecyclePhase = ComponentLifecyclePhase.Render
 	local renderResult = instance:render()

--- a/src/Component.lua
+++ b/src/Component.lua
@@ -197,6 +197,35 @@ function Component:render()
 end
 
 --[[
+	Retrieves the context object corresponding to the given key
+]]
+function Component:__getContext(key)
+	if config.internalTypeChecks then
+		internalAssert(Type.of(self) == Type.StatefulComponentInstance, "Invalid use of `__getContext`")
+	end
+
+	local virtualNode = self[InternalData].virtualNode
+	local context = virtualNode.context or virtualNode.inheritedContext
+
+	return context[key]
+end
+
+--[[
+	Adds new context property to this component's context map (which will be
+	passed down to child components)
+]]
+function Component:__addContext(key, value)
+	if config.internalTypeChecks then
+		internalAssert(Type.of(self) == Type.StatefulComponentInstance, "Invalid use of `__addContext`")
+	end
+
+	local existing = self:__getContext()
+	local virtualNode = self[InternalData].virtualNode
+
+	virtualNode.context = assign({}, existing, { key = value })
+end
+
+--[[
 	Performs property validation if the static method validateProps is declared.
 	validateProps should follow assert's expected arguments:
 	(false, message: string) | true. The function may return a message in the

--- a/src/Component.spec/context.spec.lua
+++ b/src/Component.spec/context.spec.lua
@@ -1,0 +1,297 @@
+return function()
+	local assertDeepEqual = require(script.Parent.Parent.assertDeepEqual)
+	local createElement = require(script.Parent.Parent.createElement)
+	local createReconciler = require(script.Parent.Parent.createReconciler)
+	local NoopRenderer = require(script.Parent.Parent.NoopRenderer)
+	local oneChild = require(script.Parent.Parent.oneChild)
+
+	local Component = require(script.Parent.Parent.Component)
+
+	local noopReconciler = createReconciler(NoopRenderer)
+
+	it("should be provided as an internal api on Component", function()
+		local Provider = Component:extend("Provider")
+
+		function Provider:init()
+			self:__addContext("foo", "bar")
+		end
+
+		function Provider:render()
+		end
+
+		local element = createElement(Provider)
+		local hostParent = nil
+		local hostKey = "Provider"
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey)
+
+		local expectedContext = {
+			foo = "bar",
+		}
+
+		assertDeepEqual(node.context, expectedContext)
+	end)
+
+	it("should be inherited from parent stateful nodes", function()
+		local Consumer = Component:extend("Consumer")
+
+		local capturedContext
+		function Consumer:init()
+			capturedContext = {
+				hello = self:__getContext("hello"),
+				value = self:__getContext("value"),
+			}
+		end
+
+		function Consumer:render()
+		end
+
+		local Parent = Component:extend("Parent")
+
+		function Parent:render()
+			return createElement(Consumer)
+		end
+
+		local element = createElement(Parent)
+		local hostParent = nil
+		local hostKey = "Parent"
+		local context = {
+			hello = "world",
+			value = 6,
+		}
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
+
+		expect(capturedContext).never.to.equal(context)
+		expect(capturedContext).never.to.equal(node.context)
+		assertDeepEqual(node.context, context)
+		assertDeepEqual(capturedContext, context)
+	end)
+
+	it("should be inherited from parent function nodes", function()
+		local Consumer = Component:extend("Consumer")
+
+		local capturedContext
+		function Consumer:init()
+			capturedContext = {
+				hello = self:__getContext("hello"),
+				value = self:__getContext("value"),
+			}
+		end
+
+		function Consumer:render()
+		end
+
+		local function Parent()
+			return createElement(Consumer)
+		end
+
+		local element = createElement(Parent)
+		local hostParent = nil
+		local hostKey = "Parent"
+		local context = {
+			hello = "world",
+			value = 6,
+		}
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
+
+		expect(capturedContext).never.to.equal(context)
+		expect(capturedContext).never.to.equal(node.context)
+		assertDeepEqual(node.context, context)
+		assertDeepEqual(capturedContext, context)
+	end)
+
+	it("should not copy the context table if it doesn't need to", function()
+		local Parent = Component:extend("Parent")
+
+		function Parent:init()
+			self:__addContext("parent", "I'm here!")
+		end
+
+		function Parent:render()
+			-- Create some child element
+			return createElement(function() end)
+		end
+
+		local element = createElement(Parent)
+		local hostParent = nil
+		local hostKey = "Parent"
+		local parentNode = noopReconciler.mountVirtualNode(element, hostParent, hostKey)
+
+		local expectedContext = {
+			parent = "I'm here!",
+		}
+
+		assertDeepEqual(parentNode.context, expectedContext)
+
+		local childNode = oneChild(parentNode.children)
+
+		-- Parent and child should have the same context table
+		expect(parentNode.context, childNode.context)
+	end)
+
+	it("should not allow context to move up the tree", function()
+		local ChildProvider = Component:extend("ChildProvider")
+
+		function ChildProvider:init()
+			self:__addContext("child", "I'm here too!")
+		end
+
+		function ChildProvider:render()
+		end
+
+		local ParentProvider = Component:extend("ParentProvider")
+
+		function ParentProvider:init()
+			self:__addContext("parent", "I'm here!")
+		end
+
+		function ParentProvider:render()
+			return createElement(ChildProvider)
+		end
+
+		local element = createElement(ParentProvider)
+		local hostParent = nil
+		local hostKey = "Parent"
+
+		local parentNode = noopReconciler.mountVirtualNode(element, hostParent, hostKey)
+		local childNode = oneChild(parentNode.children)
+
+		local expectedParentContext = {
+			parent = "I'm here!",
+			-- Context does not travel back up
+		}
+
+		local expectedChildContext = {
+			parent = "I'm here!",
+			child = "I'm here too!"
+		}
+
+		assertDeepEqual(parentNode.context, expectedParentContext)
+		assertDeepEqual(childNode.context, expectedChildContext)
+	end)
+
+	it("should contain values put into the tree by parent nodes", function()
+		local Consumer = Component:extend("Consumer")
+
+		local capturedContext
+		function Consumer:init()
+			capturedContext = {
+				dont = self:__getContext("dont"),
+				frob = self:__getContext("frob"),
+			}
+		end
+
+		function Consumer:render()
+		end
+
+		local Provider = Component:extend("Provider")
+
+		function Provider:init()
+			self:__addContext("frob", "ulator")
+		end
+
+		function Provider:render()
+			return createElement(Consumer)
+		end
+
+		local element = createElement(Provider)
+		local hostParent = nil
+		local hostKey = "Consumer"
+		local context = {
+			dont = "try it",
+		}
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
+
+		local initialContext = {
+			dont = "try it",
+		}
+
+		local expectedContext = {
+			dont = "try it",
+			frob = "ulator",
+		}
+
+		-- Because components mutate context, we're careful with equality
+		expect(node.context).never.to.equal(context)
+		expect(capturedContext).never.to.equal(context)
+		expect(capturedContext).never.to.equal(node.context)
+
+		assertDeepEqual(context, initialContext)
+		assertDeepEqual(node.context, expectedContext)
+		assertDeepEqual(capturedContext, expectedContext)
+	end)
+
+	it("should transfer context to children that are replaced", function()
+		local ConsumerA = Component:extend("ConsumerA")
+
+		local function captureAllContext(component)
+			return {
+				A = component:__getContext("A"),
+				B = component:__getContext("B"),
+				frob = component:__getContext("frob"),
+			}
+		end
+
+		local capturedContextA
+		function ConsumerA:init()
+			self:__addContext("A", "hello")
+
+			capturedContextA = captureAllContext(self)
+		end
+
+		function ConsumerA:render()
+		end
+
+		local ConsumerB = Component:extend("ConsumerB")
+
+		local capturedContextB
+		function ConsumerB:init()
+			self:__addContext("B", "hello")
+
+			capturedContextB = captureAllContext(self)
+		end
+
+		function ConsumerB:render()
+		end
+
+		local Provider = Component:extend("Provider")
+
+		function Provider:init()
+			self:__addContext("frob", "ulator")
+		end
+
+		function Provider:render()
+			local useConsumerB = self.props.useConsumerB
+
+			if useConsumerB then
+				return createElement(ConsumerB)
+			else
+				return createElement(ConsumerA)
+			end
+		end
+
+		local hostParent = nil
+		local hostKey = "Consumer"
+
+		local element = createElement(Provider)
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey)
+
+		local expectedContextA = {
+			frob = "ulator",
+			A = "hello",
+		}
+
+		assertDeepEqual(capturedContextA, expectedContextA)
+
+		local expectedContextB = {
+			frob = "ulator",
+			B = "hello",
+		}
+
+		local replacedElement = createElement(Provider, {
+			useConsumerB = true,
+		})
+		noopReconciler.updateVirtualNode(node, replacedElement)
+
+		assertDeepEqual(capturedContextB, expectedContextB)
+	end)
+end

--- a/src/Component.spec/context.spec.lua
+++ b/src/Component.spec/context.spec.lua
@@ -125,7 +125,7 @@ return function()
 		local childNode = oneChild(parentNode.children)
 
 		-- Parent and child should have the same context table
-		expect(parentNode.context, childNode.context)
+		expect(parentNode.context).to.equal(childNode.context)
 	end)
 
 	it("should not allow context to move up the tree", function()

--- a/src/Component.spec/legacyContext.spec.lua
+++ b/src/Component.spec/legacyContext.spec.lua
@@ -27,7 +27,7 @@ return function()
 			foo = "bar",
 		}
 
-		assertDeepEqual(node.context, expectedContext)
+		assertDeepEqual(node.legacyContext, expectedContext)
 	end)
 
 	it("should be inherited from parent stateful nodes", function()
@@ -57,8 +57,8 @@ return function()
 		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
 
 		expect(capturedContext).never.to.equal(context)
-		expect(capturedContext).never.to.equal(node.context)
-		assertDeepEqual(node.context, context)
+		expect(capturedContext).never.to.equal(node.legacyContext)
+		assertDeepEqual(node.legacyContext, context)
 		assertDeepEqual(capturedContext, context)
 	end)
 
@@ -87,8 +87,8 @@ return function()
 		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
 
 		expect(capturedContext).never.to.equal(context)
-		expect(capturedContext).never.to.equal(node.context)
-		assertDeepEqual(node.context, context)
+		expect(capturedContext).never.to.equal(node.legacyContext)
+		assertDeepEqual(node.legacyContext, context)
 		assertDeepEqual(capturedContext, context)
 	end)
 
@@ -131,12 +131,12 @@ return function()
 		}
 
 		-- Because components mutate context, we're careful with equality
-		expect(node.context).never.to.equal(context)
+		expect(node.legacyContext).never.to.equal(context)
 		expect(capturedContext).never.to.equal(context)
-		expect(capturedContext).never.to.equal(node.context)
+		expect(capturedContext).never.to.equal(node.legacyContext)
 
 		assertDeepEqual(context, initialContext)
-		assertDeepEqual(node.context, expectedContext)
+		assertDeepEqual(node.legacyContext, expectedContext)
 		assertDeepEqual(capturedContext, expectedContext)
 	end)
 

--- a/src/Component.spec/legacyContext.spec.lua
+++ b/src/Component.spec/legacyContext.spec.lua
@@ -54,7 +54,7 @@ return function()
 			hello = "world",
 			value = 6,
 		}
-		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, nil, context)
 
 		expect(capturedContext).never.to.equal(context)
 		expect(capturedContext).never.to.equal(node.legacyContext)
@@ -84,7 +84,7 @@ return function()
 			hello = "world",
 			value = 6,
 		}
-		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, nil, context)
 
 		expect(capturedContext).never.to.equal(context)
 		expect(capturedContext).never.to.equal(node.legacyContext)
@@ -119,7 +119,7 @@ return function()
 		local context = {
 			dont = "try it",
 		}
-		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, context)
+		local node = noopReconciler.mountVirtualNode(element, hostParent, hostKey, nil, context)
 
 		local initialContext = {
 			dont = "try it",

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -805,7 +805,7 @@ return function()
 		end)
 	end)
 
-	describe("Context", function()
+	describe("Legacy context", function()
 		it("should pass context values through Roblox host nodes", function()
 			local Consumer = Component:extend("Consumer")
 
@@ -825,7 +825,7 @@ return function()
 			local context = {
 				hello = "world",
 			}
-			local node = reconciler.mountVirtualNode(element, hostParent, hostKey, context)
+			local node = reconciler.mountVirtualNode(element, hostParent, hostKey, nil, context)
 
 			expect(capturedContext).never.to.equal(context)
 			assertDeepEqual(capturedContext, context)

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -946,5 +946,4 @@ return function()
 			})
 		end)
 	end)
-	
 end

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -264,7 +264,7 @@ local function createReconciler(renderer)
 			internalAssert(typeof(context) == "table" or context == nil, "Expected arg #4 to be of type table or nil")
 			internalAssert(
 				typeof(legacyContext) == "table" or legacyContext == nil,
-				"Expected arg #4 to be of type table or nil"
+				"Expected arg #5 to be of type table or nil"
 			)
 		end
 		if config.typeChecks then

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -335,7 +335,7 @@ local function createReconciler(renderer)
 			internalAssert(renderer.isHostObject(hostParent) or hostParent == nil, "Expected arg #2 to be a host object")
 			internalAssert(
 				typeof(legacyContext) == "table" or legacyContext == nil,
-				"Expected arg #4 to be of type table or nil"
+				"Expected arg #5 to be of type table or nil"
 			)
 		end
 		if config.typeChecks then

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -261,6 +261,7 @@ local function createReconciler(renderer)
 	local function createVirtualNode(element, hostParent, hostKey, context, legacyContext)
 		if config.internalTypeChecks then
 			internalAssert(renderer.isHostObject(hostParent) or hostParent == nil, "Expected arg #2 to be a host object")
+			internalAssert(typeof(context) == "table" or context == nil, "Expected arg #4 to be of type table or nil")
 			internalAssert(
 				typeof(legacyContext) == "table" or legacyContext == nil,
 				"Expected arg #4 to be of type table or nil"
@@ -283,18 +284,18 @@ local function createReconciler(renderer)
 			hostKey = hostKey,
 
 			-- Legacy Context API
+			-- A table of context values inherited from the parent node
 			legacyContext = legacyContext,
-			-- This copy of legacyContext is useful if the element gets replaced
-			-- with an element of a different component type
+
+			-- A saved copy of the parent context, used when replacing a node
 			parentLegacyContext = legacyContext,
 
 			-- Context API
-			-- The inherited context from this node's parent
-			context = context,
+			-- A table of context values inherited from the parent node
+			context = context or {},
 
-			-- A saved copy of the unmodified context; this will be saved when
-			-- a component adds new context, and will be used when a component
-			-- is replaced
+			-- A saved copy of the unmodified context; this will be updated when
+			-- a component adds new context and used when a node is replaced
 			originalContext = nil,
 		}
 	end

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -31,16 +31,16 @@ local function createReconciler(renderer)
 		Unmount the given virtualNode, replacing it with a new node described by
 		the given element.
 
-		Preserves host properties, depth, and context from parent.
+		Preserves host properties, depth, and legacyContext from parent.
 	]]
 	local function replaceVirtualNode(virtualNode, newElement)
 		local hostParent = virtualNode.hostParent
 		local hostKey = virtualNode.hostKey
 		local depth = virtualNode.depth
-		local parentContext = virtualNode.parentContext
+		local parentLegacyContext = virtualNode.parentLegacyContext
 
 		unmountVirtualNode(virtualNode)
-		local newNode = mountVirtualNode(newElement, hostParent, hostKey, parentContext)
+		local newNode = mountVirtualNode(newElement, hostParent, hostKey, parentLegacyContext)
 
 		-- mountVirtualNode can return nil if the element is a boolean
 		if newNode ~= nil then
@@ -85,7 +85,7 @@ local function createReconciler(renderer)
 			end
 
 			if virtualNode.children[childKey] == nil then
-				local childNode = mountVirtualNode(newElement, hostParent, concreteKey, virtualNode.context)
+				local childNode = mountVirtualNode(newElement, hostParent, concreteKey, virtualNode.legacyContext)
 
 				-- mountVirtualNode can return nil if the element is a boolean
 				if childNode ~= nil then
@@ -247,10 +247,10 @@ local function createReconciler(renderer)
 	--[[
 		Constructs a new virtual node but not does mount it.
 	]]
-	local function createVirtualNode(element, hostParent, hostKey, context)
+	local function createVirtualNode(element, hostParent, hostKey, legacyContext)
 		if config.internalTypeChecks then
 			internalAssert(renderer.isHostObject(hostParent) or hostParent == nil, "Expected arg #2 to be a host object")
-			internalAssert(typeof(context) == "table" or context == nil, "Expected arg #4 to be of type table or nil")
+			internalAssert(typeof(legacyContext) == "table" or legacyContext == nil, "Expected arg #4 to be of type table or nil")
 		end
 		if config.typeChecks then
 			assert(hostKey ~= nil, "Expected arg #3 to be non-nil")
@@ -267,10 +267,10 @@ local function createReconciler(renderer)
 			children = {},
 			hostParent = hostParent,
 			hostKey = hostKey,
-			context = context,
-			-- This copy of context is useful if the element gets replaced
+			legacyContext = legacyContext,
+			-- This copy of legacyContext is useful if the element gets replaced
 			-- with an element of a different component type
-			parentContext = context,
+			parentLegacyContext = legacyContext,
 		}
 	end
 
@@ -304,10 +304,10 @@ local function createReconciler(renderer)
 		Constructs a new virtual node and mounts it, but does not place it into
 		the tree.
 	]]
-	function mountVirtualNode(element, hostParent, hostKey, context)
+	function mountVirtualNode(element, hostParent, hostKey, legacyContext)
 		if config.internalTypeChecks then
 			internalAssert(renderer.isHostObject(hostParent) or hostParent == nil, "Expected arg #2 to be a host object")
-			internalAssert(typeof(context) == "table" or context == nil, "Expected arg #4 to be of type table or nil")
+			internalAssert(typeof(legacyContext) == "table" or legacyContext == nil, "Expected arg #4 to be of type table or nil")
 		end
 		if config.typeChecks then
 			assert(hostKey ~= nil, "Expected arg #3 to be non-nil")
@@ -324,7 +324,7 @@ local function createReconciler(renderer)
 
 		local kind = ElementKind.of(element)
 
-		local virtualNode = createVirtualNode(element, hostParent, hostKey, context)
+		local virtualNode = createVirtualNode(element, hostParent, hostKey, legacyContext)
 
 		if kind == ElementKind.Host then
 			renderer.mountHostNode(reconciler, virtualNode)


### PR DESCRIPTION
Works towards #4. This is a prerequisite for the new _public_ Context API proposed in #246.

This change introduced two new methods to the `Component` API:

* `Component:__addContext(key, value)` - Adds a new entry to the context table. This will be available to this component and all of its children, and is intended to be used in a Provider component.
* `Component:__getContext(key)` - Retrieves the context value for the given key. This intended to be used by a Consumer component.

This interface allows us to avoid defensive copying, as even internal Component APIs do not get direct access to the context table. The legacy context API is still present and usable, and will not be affected by these changes.

Checklist before submitting:
* ~~Added entry to `CHANGELOG.md`~~ (this should come with the changes in #246)
* [x] Added/updated relevant tests
* [x] Added/updated documentation (documentation here consists of code comments, public docs will be part of #246)