### PR TITLE
Add support for running tests via Roblox CLI

### DIFF
--- a/bin/run-tests.server.lua
+++ b/bin/run-tests.server.lua
@@ -1,6 +1,7 @@
 -- luacheck: globals __LEMUR__
 
 local ReplicatedStorage = game:GetService("ReplicatedStorage")
+local isRobloxCli, ProcessService = pcall(game.GetService, game, "ProcessService")
 
 local Roact = require(ReplicatedStorage.Roact)
 local TestEZ = require(ReplicatedStorage.TestEZ)
@@ -13,8 +14,12 @@ Roact.setGlobalConfig({
 })
 local results = TestEZ.TestBootstrap:run(ReplicatedStorage.Roact, TestEZ.Reporters.TextReporter)
 
+local statusCode = results.failureCount == 0 and 0 or 1
+
 if __LEMUR__ then
 	if results.failureCount > 0 then
-		os.exit(1)
+		os.exit(statusCode)
 	end
+elseif isRobloxCli then
+	ProcessService:Exit(statusCode)
 end

--- a/bin/test-roblox-cli.sh
+++ b/bin/test-roblox-cli.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+
+# Usage: ./bin/test-roblox-cli.sh
+
+if [ ! -z ${LOCALAPPDATA+x} ]; then
+	# Probably Windows, look for any Roblox installation in the default path.
+
+	VERSIONS_FOLDER="$LOCALAPPDATA/Roblox/Versions"
+	INSTALL=`find "$VERSIONS_FOLDER" -maxdepth 1 -name version-* | head -1`
+	CONTENT="$INSTALL/content"
+else
+	# Probably macOS, look for Roblox Studio in its default path.
+
+	CONTENT="/Applications/RobloxStudio.App/Contents/Resources/content"
+fi
+
+rojo build place.project.json -o TestPlace.rbxlx
+roblox-cli run --load.place TestPlace.rbxlx --assetFolder "$CONTENT"


### PR DESCRIPTION
At Roblox, we have an internally utility that's a command line version of Roblox. For people that can use it, it's preferable to use roblox-cli instead of Lemur because of easier setup and improved accuracy.

We'll still be maintaining Lemur as the source of truth for CI builds for the foreseeable future, and this PR does not break running tests under Lemur.