### PR TITLE
Fix prop-context update tearing

### DIFF
--- a/src/createContext.lua
+++ b/src/createContext.lua
@@ -102,7 +102,9 @@ local function createConsumer(context)
 			--
 			-- To avoid sending a redundant update, we compare the new value
 			-- with the last value that we updated with (set in didUpdate) and
-			-- only update if they differ.
+			-- only update if they differ. This may happen when an update from a
+			-- provider was blocked by an intermediate component that returned
+			-- false from shouldUpdate.
 			self.disconnect = self.contextEntry.onUpdate:subscribe(function(newValue)
 				if newValue ~= self.lastValue then
 					-- Trigger a dummy state update.

--- a/src/createContext.lua
+++ b/src/createContext.lua
@@ -34,7 +34,7 @@ local function createProvider(context)
 	end
 
 	function Provider:didUpdate(prevProps)
-		-- If the provided value change, after we've updated every reachable
+		-- If the provided value changed, after we've updated every reachable
 		-- component, fire a signal to update the rest.
 		--
 		-- This signal will notify all context consumers. It's expected that

--- a/src/createContext.lua
+++ b/src/createContext.lua
@@ -1,22 +1,50 @@
 local Symbol = require(script.Parent.Symbol)
-local Binding = require(script.Parent.Binding)
 local createFragment = require(script.Parent.createFragment)
+local createSignal = require(script.Parent.createSignal)
 local Children = require(script.Parent.PropMarkers.Children)
 local Component = require(script.Parent.Component)
+
+--[[
+	Construct the value that is assigned to Roact's context storage.
+]]
+local function createContextEntry(currentValue)
+	return {
+		value = currentValue,
+		onUpdate = createSignal(),
+	}
+end
 
 local function createProvider(context)
 	local Provider = Component:extend("Provider")
 
 	function Provider:init(props)
-		self.binding, self.updateValue = Binding.create(props.value)
+		self.contextEntry = createContextEntry(props.value)
+		self:__addContext(context.key, self.contextEntry)
+	end
 
-		local key = context.key
-		self:__addContext(key, self.binding)
+	function Provider:willUpdate(nextProps)
+		-- If the provided value changed, immediately update the context entry.
+		--
+		-- During this update, any components that are reachable will receive
+		-- this updated value at the same time as any props and state updates
+		-- that are being applied.
+		if nextProps.value ~= self.props.value then
+			self.contextEntry.value = nextProps.value
+		end
 	end
 
 	function Provider:didUpdate(prevProps)
+		-- If the provided value change, after we've updated every reachable
+		-- component, fire a signal to update the rest.
+		--
+		-- This signal will notify all context consumers. It's expected that
+		-- they will compare the last context value they updated with and only
+		-- trigger an update on themselves if this value is different.
+		--
+		-- This codepath will generally only update consumer components that has
+		-- a component implementing shouldUpdate between them and the provider.
 		if prevProps.value ~= self.props.value then
-			self.updateValue(self.props.value)
+			self.contextEntry.onUpdate:fire(self.props.value)
 		end
 	end
 
@@ -30,29 +58,6 @@ end
 local function createConsumer(context)
 	local Consumer = Component:extend("Consumer")
 
-	function Consumer:init(props)
-		local key = context.key
-		local binding = self:__getContext(key)
-
-		if binding ~= nil then
-			self.state = {
-				value = binding:getValue(),
-			}
-
-			-- Update if the Context updated
-			self.disconnect = Binding.subscribe(binding, function()
-				self:setState({
-					value = binding:getValue(),
-				})
-			end)
-		else
-			-- Fall back to the default value if no Provider exists
-			self.state = {
-				value = context.defaultValue,
-			}
-		end
-	end
-
 	function Consumer.validateProps(props)
 		if type(props.render) ~= "function" then
 			return false, "Consumer expects a `render` function"
@@ -61,8 +66,50 @@ local function createConsumer(context)
 		end
 	end
 
+	function Consumer:init(props)
+		-- This value may be nil, which indicates that our consumer is not a
+		-- descendant of a provider for this context item.
+		self.contextEntry = self:__getContext(context.key)
+	end
+
 	function Consumer:render()
-		return self.props.render(self.state.value)
+		-- Render using the latest available for this context item.
+		--
+		-- We don't store this value in state in order to have more fine-grained
+		-- control over our update behavior.
+		local value
+		if self.contextEntry ~= nil then
+			value = self.contextEntry.value
+		else
+			value = context.defaultValue
+		end
+
+		return self.props.render(value)
+	end
+
+	function Consumer:didUpdate()
+		-- Store the value that we most recently updated with.
+		--
+		-- This value is compared in the contextEntry onUpdate hook below.
+		self.lastValue = self.contextEntry.value
+	end
+
+	function Consumer:didMount()
+		if self.contextEntry ~= nil then
+			-- When onUpdate is fired, a new value has been made available in
+			-- this context entry, but we may have already updated in the same
+			-- update cycle.
+			--
+			-- To avoid sending a redundant update, we compare the new value
+			-- with the last value that we updated with (set in didUpdate) and
+			-- only update if they differ.
+			self.disconnect = self.contextEntry.onUpdate:subscribe(function(newValue)
+				if newValue ~= self.lastValue then
+					-- Trigger a dummy state update.
+					self:setState({})
+				end
+			end)
+		end
 	end
 
 	function Consumer:willUnmount()
@@ -78,12 +125,10 @@ local Context = {}
 Context.__index = Context
 
 function Context.new(defaultValue)
-	local self = {
+	return setmetatable({
 		defaultValue = defaultValue,
 		key = Symbol.named("ContextKey"),
-	}
-	setmetatable(self, Context)
-	return self
+	}, Context)
 end
 
 function Context:__tostring()
@@ -92,6 +137,7 @@ end
 
 local function createContext(defaultValue)
 	local context = Context.new(defaultValue)
+
 	return {
 		Provider = createProvider(context),
 		Consumer = createConsumer(context),

--- a/src/createContext.spec.lua
+++ b/src/createContext.spec.lua
@@ -113,7 +113,7 @@ return function()
 				Listener = createElement(Listener),
 			}))
 
-			expect(valueSpy.callCount).to.equal(3)
+			expect(valueSpy.callCount).to.equal(2)
 			valueSpy:assertCalledWith("ThirdTest")
 
 			noopReconciler.unmountVirtualTree(tree)
@@ -179,12 +179,15 @@ return function()
 			-- second state combinations we want to visit.
 			local observedA = false
 			local observedB = false
+			local updateCount = 0
 
 			local context = createContext("default")
 
 			local function Listener(props)
 				return createElement(context.Consumer, {
 					render = function(value)
+						updateCount = updateCount + 1
+
 						if value == "context_1" then
 							expect(props.someProp).to.equal("prop_1")
 							observedA = true
@@ -217,6 +220,7 @@ return function()
 			local tree = noopReconciler.mountVirtualTree(element1, nil, "UpdateObservationIsFun")
 			noopReconciler.updateVirtualTree(tree, element2)
 
+			expect(updateCount).to.equal(2)
 			expect(observedA).to.equal(true)
 			expect(observedB).to.equal(true)
 		end)


### PR DESCRIPTION
Closes #259.

This PR tries to fix the update tearing behavior I discovered and reported in #259 based on a solution that my team has been discussing. I introduced a fairly small and robust test that is currently failing to indicate the problem with our current state and the quick-fix solutions to this problem.

Context values are no longer based on bindings and now instead use a small cell that contains a value and an update signal.

Providers now update context values in two passes:
1. In `willUpdate`, the provider updates the value of the context entry but do not fire any signals. This should cause downstream consumers to be able to immediately read the new value on their next render. Their next render will occur immediately unless an intermediate component implements `shouldUpdate`.
2. In `didUpdate`, the provider fires the signal portion of the context entry. This will notify any consumers.

Consumers are now a little dumber and simpler. They no longer track the current context value in state, but instead track the last value they were updated with. When an update signal is received from their corresponding provider's `didUpdate` hook, consumers now compare the new value with the value they were last updated with, stored in their `didUpdate` hook. If these values differ, we can assume that there was a component between the consumer and provider that returned `false` to `shouldUpdate`, and trigger an update.

I dramatically increased the documentation around affected code to make these kinds of issues more clear to us in the future.

## TODO
* [x] Failing test and bug explanation in source code
* [x] Actually fix behavior

Checklist before submitting:
* ~Added entry to `CHANGELOG.md`~
    * We didn't make a release with the broken context API, so this should roll up under just introducing this feature.
* [x] Added/updated relevant tests
* ~Added/updated documentation~
    * No user-visible changes because this feature has not been released yet.