### PR TITLE
Fix missing nil check in context logic

### DIFF
--- a/src/createContext.lua
+++ b/src/createContext.lua
@@ -91,7 +91,9 @@ local function createConsumer(context)
 		-- Store the value that we most recently updated with.
 		--
 		-- This value is compared in the contextEntry onUpdate hook below.
-		self.lastValue = self.contextEntry.value
+		if self.contextEntry ~= nil then
+			self.lastValue = self.contextEntry.value
+		end
 	end
 
 	function Consumer:didMount()

--- a/src/createContext.spec.lua
+++ b/src/createContext.spec.lua
@@ -173,6 +173,27 @@ return function()
 
 			noopReconciler.unmountVirtualTree(tree)
 		end)
+
+		it("should behave correctly when the default value is nil", function()
+			local context = createContext(nil)
+
+			local valueSpy = createSpy()
+			local function Listener()
+				return createElement(context.Consumer, {
+					render = valueSpy.value,
+				})
+			end
+
+			local tree = noopReconciler.mountVirtualTree(createElement(Listener), nil, "Provide Tree")
+			expect(valueSpy.callCount).to.equal(1)
+			valueSpy:assertCalledWith(nil)
+
+			tree = noopReconciler.updateVirtualTree(tree, createElement(Listener))
+			noopReconciler.unmountVirtualTree(tree)
+
+			expect(valueSpy.callCount).to.equal(2)
+			valueSpy:assertCalledWith(nil)
+		end)
 	end)
 
 	describe("Update order", function()


### PR DESCRIPTION
I discovered a problem with context where consumers that accepted a nil context value would have errors thrown whenever they get re-erendered. This fixes that issue with a simple nil check. likely just an oversight.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] Added/updated documentation