### PR TITLE
Allow getting global config

### DIFF
--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -253,6 +253,13 @@ Enabling `elementTracing` also allows the use of the [getElementTraceback](#gete
 #### propValidation
 Enables validation of props via the [validateProps](#validateprops) method on components. With this flag enabled, any validation written by component authors in a component's `validateProps` method will be run on every prop change. This is helpful during development for making sure components are being used correctly.
 
+### Roact.getGlobalConfig
+```
+Roact.getGlobalConfig() -> Dictionary<string, bool>
+```
+
+This is used to get the current config values. This can be useful if you wish to run some portion of your unit tests with elementTracing or propValidation turned on and some with these turned off. Using this tests can reset the config to the previous value after they run.
+
 ---
 
 ## Constants

--- a/src/init.lua
+++ b/src/init.lua
@@ -39,6 +39,7 @@ local Roact = strict {
 	reconcile = reconcilerCompat.reconcile,
 
 	setGlobalConfig = GlobalConfig.set,
+	getGlobalConfig = GlobalConfig.get,
 
 	-- APIs that may change in the future without warning
 	UNSTABLE = {

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -13,6 +13,7 @@ return function()
 			update = "function",
 			oneChild = "function",
 			setGlobalConfig = "function",
+			getGlobalConfig = "function",
 			createContext = "function",
 
 			-- These functions are deprecated and throw warnings!


### PR DESCRIPTION
In the InGameMenu, we have a test that does the following:

```
	it("should throw when passed a selectedIndex out of bounds when propvalidation is turned on", function()
		Roact.setGlobalConfig({
			propValidation = true,
		})
```

The problem with this is that all the tests that come before it run with propValidation off and all the tests after it run with propValidation on. Should we expose the Roact GlobalConfig to allow tests that want to do things like this (or turn off propValidation for some reason) to reset the global config to the previous value?

I'm not fully committed to this idea if we think this might encourage bad practices but think it could also be useful in other contexts like turning off property validation for certain tests temporarily while we transition to property validation turned on for all tests.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] Added/updated documentation