### PR TITLE
Add component name to property validation error message

### DIFF
--- a/.github/workflows/clabot.yml
+++ b/.github/workflows/clabot.yml
@@ -14,7 +14,7 @@ jobs:
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        whitelist: "LPGhatguy,ZoteTheMighty,cliffchapmanrbx,MisterUncloaked,matthargett"
+        whitelist: "LPGhatguy,ZoteTheMighty,cliffchapmanrbx,MisterUncloaked,matthargett,ConorGriffin37"
         use-remote-repo: true
         remote-repo-name: "roblox/cla-bot-store"
         remote-repo-pat: ${{ secrets.CLA_REMOTE_REPO_PAT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased Changes
 
-* Added component name to property validation error message
+* Added component name to property validation error message ([#275](https://github.com/Roblox/roact/pull/275))
 
 ## [1.3.0](https://github.com/Roblox/roact/releases/tag/v1.3.0) (May 5th, 2020)
 * Added Contexts, which enables easy handling of items that are provided and consumed throughout the tree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+* Added component name to property validation error message
+
 ## [1.3.0](https://github.com/Roblox/roact/releases/tag/v1.3.0) (May 5th, 2020)
 * Added Contexts, which enables easy handling of items that are provided and consumed throughout the tree.
 

--- a/src/Component.lua
+++ b/src/Component.lua
@@ -265,7 +265,8 @@ function Component:__validateProps(props)
 
 	if not success then
 		failureReason = failureReason or "<Validator function did not supply a message>"
-		error(("Property validation failed: %s\n\n%s"):format(
+		error(("Property validation failed in %s: %s\n\n%s"):format(
+			self.__componentName,
 			tostring(failureReason),
 			self:getElementTraceback() or "<enable element tracebacks>"),
 		0)

--- a/src/Component.spec/validateProps.spec.lua
+++ b/src/Component.spec/validateProps.spec.lua
@@ -164,6 +164,34 @@ return function()
 		end)
 	end)
 
+	it("should include the component name in the error message", function()
+		local config = {
+			propValidation = true,
+		}
+
+		GlobalConfig.scoped(config, function()
+			local MyComponent = Component:extend("MyComponent")
+			MyComponent.validateProps = function()
+				return false
+			end
+
+			function MyComponent:render()
+				return nil
+			end
+
+			local element = createElement(MyComponent)
+			local hostParent = nil
+			local key = "Test"
+
+			local success, error = pcall(function()
+				noopReconciler.mountVirtualNode(element, hostParent, key)
+			end)
+
+			expect(success).to.equal(false)
+			expect(error:find("MyComponent")).to.be.ok()
+		end)
+	end)
+
 	it("should be invoked after defaultProps are applied", function()
 		local config = {
 			propValidation = true,

--- a/src/Component.spec/validateProps.spec.lua
+++ b/src/Component.spec/validateProps.spec.lua
@@ -188,7 +188,8 @@ return function()
 			end)
 
 			expect(success).to.equal(false)
-			expect(error:find("MyComponent")).to.be.ok()
+			local startIndex = error:find("MyComponent")
+			expect(startIndex).to.be.ok()
 		end)
 	end)
 


### PR DESCRIPTION
Add componentName to property validation error message. This would be helpful in cases where element tracing is not turned on or provides an unhelpful error message.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] Added/updated documentation