### PR TITLE
Disconnect events during unmount

### DIFF
--- a/src/RobloxRenderer.lua
+++ b/src/RobloxRenderer.lua
@@ -230,6 +230,10 @@ function RobloxRenderer.unmountHostNode(reconciler, virtualNode)
 
 	applyRef(element.props[Ref], nil)
 
+	if virtualNode.eventManager ~= nil then
+		virtualNode.eventManager:disconnectAll()
+	end
+
 	for _, childNode in pairs(virtualNode.children) do
 		reconciler.unmountVirtualNode(childNode)
 	end

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -11,6 +11,7 @@ return function()
 	local GlobalConfig = require(script.Parent.GlobalConfig)
 	local Portal = require(script.Parent.Portal)
 	local Ref = require(script.Parent.PropMarkers.Ref)
+	local Event = require(script.Parent.PropMarkers.Event)
 
 	local RobloxRenderer = require(script.Parent.RobloxRenderer)
 
@@ -540,6 +541,25 @@ return function()
 
 			expect(spyRef.callCount).to.equal(2)
 			spyRef:assertCalledWith(nil)
+		end)
+
+		itSKIP("should not process events when unmounting", function()
+			local parent = Instance.new("Folder")
+			local key = "Some Key"
+
+			local element = createElement("Frame", {
+				[Event.ChildRemoved] = function(instance)
+					error("this callback should not be called during unmount")
+				end,
+			}, {
+				Child = createElement("Frame"),
+			})
+
+			local node = reconciler.createVirtualNode(element, parent, key)
+
+			RobloxRenderer.mountHostNode(reconciler, node)
+
+			RobloxRenderer.unmountHostNode(reconciler, node)
 		end)
 	end)
 

--- a/src/SingleEventManager.lua
+++ b/src/SingleEventManager.lua
@@ -144,4 +144,17 @@ function SingleEventManager:resume()
 	self._suspendedEventQueue = {}
 end
 
+function SingleEventManager:disconnectAll()
+	self._status = EventStatus.Disabled
+
+	for eventKey, connection in pairs(self._connections) do
+		connection:Disconnect()
+		self._listeners[eventKey] = nil
+	end
+
+	self._listeners = {}
+	self._connections = {}
+	self._suspendedEventQueue = {}
+end
+
 return SingleEventManager

--- a/src/SingleEventManager.spec.lua
+++ b/src/SingleEventManager.spec.lua
@@ -236,4 +236,22 @@ return function()
 			end).to.throw()
 		end)
 	end)
+
+	describe("disconnectAll", function()
+		it("should not invoke events fired during suspension but disconnected before resumption", function()
+			local instance = Instance.new("BindableEvent")
+			local manager = SingleEventManager.new(instance)
+			local eventSpy = createSpy()
+
+			manager:connectEvent("Event", eventSpy.value)
+			manager:suspend()
+
+			instance:Fire(1)
+
+			manager:disconnectAll()
+
+			manager:resume()
+			expect(eventSpy.callCount).to.equal(0)
+		end)
+	end)
 end


### PR DESCRIPTION
Closes #235.

Change RobloxRenderer to disconnect all events during unmount, by adding a method `disconnectAll` to the SingleEventManager.

The test I added to RobloxRenderer is currently skipped, because lemur does not have the `ChildRemoved` event implemented. However, the test passes when testing in studio. Let me know if I should go implement lemur or if you have any other ideas about how I could test this.

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation