### PR TITLE
Fix Roact.forwardRef description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Roact Changelog
 
 ## Unreleased Changes
+* Fixed forwardRef description ([#312](https://github.com/Roblox/roact/pull/312)).
 
 ## [1.4.0](https://github.com/Roblox/roact/releases/tag/v1.4.0) (November 19th, 2020)
 * Introduce forwardRef ([#307](https://github.com/Roblox/roact/pull/307)).

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -184,7 +184,7 @@ Creates a new reference object that can be used with [Roact.Ref](#roactref).
 !!! success "Added in Roact 1.4.0"
 
 ```
-Roact.createRef(render: (props: table, ref: Ref) -> RoactElement) -> RoactComponent
+Roact.forwardRef(render: (props: table, ref: Ref) -> RoactElement) -> RoactComponent
 ```
 
 Creates a new component given a render function that accepts both props and a ref, allowing a ref to be forwarded to an underlying host component via [Roact.Ref](#roactref).


### PR DESCRIPTION
Fixes the `Roact.forwardRef` description which is currently`Roact.createRef` instead.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated documentation