### PR TITLE
Update TestEZ and fix tests so they work in studio

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -26,8 +26,9 @@ stds.testez = {
 	read_globals = {
 		"describe",
 		"it", "itFOCUS", "itSKIP",
-		"FOCUS", "SKIP", "HACK_NO_XPCALL",
+		"FOCUS", "SKIP",
 		"expect",
+		"beforeEach", "afterEach", "beforeAll", "afterAll",
 	}
 }
 

--- a/bin/run-tests.server.lua
+++ b/bin/run-tests.server.lua
@@ -12,14 +12,15 @@ Roact.setGlobalConfig({
 	["elementTracing"] = true,
 	["propValidation"] = true,
 })
-local results = TestEZ.TestBootstrap:run(ReplicatedStorage.Roact, TestEZ.Reporters.TextReporter)
+local results = TestEZ.TestBootstrap:run(
+	{ ReplicatedStorage.Roact },
+	TestEZ.Reporters.TextReporter
+)
 
-local statusCode = results.failureCount == 0 and 0 or 1
+local statusCode = (results.failureCount == 0 and #results.errors == 0) and 0 or 1
 
 if __LEMUR__ then
-	if results.failureCount > 0 then
-		os.exit(statusCode)
-	end
+	os.exit(statusCode)
 elseif isRobloxCli then
-	ProcessService:Exit(statusCode)
+	ProcessService:ExitAsync(statusCode)
 end

--- a/bin/spec.lua
+++ b/bin/spec.lua
@@ -5,7 +5,7 @@
 -- If you add any dependencies, add them to this table so they'll be loaded!
 local LOAD_MODULES = {
 	{"src", "Roact"},
-	{"modules/testez/lib", "TestEZ"},
+	{"modules/testez/src", "TestEZ"},
 }
 
 -- This makes sure we can load Lemur and other libraries that depend on init.lua

--- a/place.project.json
+++ b/place.project.json
@@ -11,7 +11,7 @@
       },
 
       "TestEZ": {
-        "$path": "modules/testez/lib"
+        "$path": "modules/testez"
       }
     },
 

--- a/src/RobloxRenderer.spec.lua
+++ b/src/RobloxRenderer.spec.lua
@@ -1,4 +1,6 @@
 return function()
+	local ReplicatedStorage = game:GetService("ReplicatedStorage")
+
 	local assertDeepEqual = require(script.Parent.assertDeepEqual)
 	local Binding = require(script.Parent.Binding)
 	local Children = require(script.Parent.PropMarkers.Children)
@@ -950,6 +952,17 @@ return function()
 
 
 	describe("Integration Tests", function()
+		local temporaryParent = nil
+		beforeEach(function()
+			temporaryParent = Instance.new("Folder")
+			temporaryParent.Parent = ReplicatedStorage
+		end)
+
+		afterEach(function()
+			temporaryParent:Destroy()
+			temporaryParent = nil
+		end)
+
 		it("should not allow re-entrancy in updateChildren", function()
 			local configValues = {
 				tempFixUpdateChildrenReEntrancy = true,
@@ -1007,7 +1020,7 @@ return function()
 				end
 
 				local parent = Instance.new("ScreenGui")
-				parent.Parent = game.CoreGui
+				parent.Parent = temporaryParent
 
 				local tree = createElement(ParentComponent)
 
@@ -1101,7 +1114,7 @@ return function()
 				end
 
 				local parent = Instance.new("ScreenGui")
-				parent.Parent = game.CoreGui
+				parent.Parent = temporaryParent
 
 				local tree = createElement(ParentComponent)
 
@@ -1235,7 +1248,7 @@ return function()
 				end
 
 				local parent = Instance.new("ScreenGui")
-				parent.Parent = game.CoreGui
+				parent.Parent = temporaryParent
 
 				local tree = createElement(ParentComponent)
 
@@ -1335,7 +1348,7 @@ return function()
 				end
 
 				local parent = Instance.new("ScreenGui")
-				parent.Parent = game.CoreGui
+				parent.Parent = temporaryParent
 
 				local tree = createElement(ParentComponent)
 


### PR DESCRIPTION
TestEZ submodule has been updated to latest.

The usage of `CoreGui` was throwing permission errors when running tests within Studio so I've replaced it with a Folder instance in ReplicatedStorage. Since I've updated TestEZ, I was able to use `beforeEach` and `afterEach` to clean up that instance.

Checklist before submitting:
* [x] ~Added entry to `CHANGELOG.md`~
* [x] Added/updated relevant tests
* [x] ~Added/updated documentation~