### PR TITLE
Fix bug in context consumers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased Changes
 
+* Fixed `Listeners can only be disconnected once` from context consumers. ([#320](https://github.com/Roblox/roact/pull/320))
+
 ## [1.4.1](https://github.com/Roblox/roact/releases/tag/v1.4.1) (August 12th, 2021)
 * Fixed a bug where the Roact tree could get into a broken state when using callbacks passed to a child component. Updated the tempFixUpdateChildrenReEntrancy config value to also handle this case. ([#315](https://github.com/Roblox/roact/pull/315))
 * Fixed forwardRef description ([#312](https://github.com/Roblox/roact/pull/312)).

--- a/src/createContext.lua
+++ b/src/createContext.lua
@@ -119,6 +119,7 @@ local function createConsumer(context)
 	function Consumer:willUnmount()
 		if self.disconnect ~= nil then
 			self.disconnect()
+			self.disconnect = nil
 		end
 	end
 


### PR DESCRIPTION
Closes #319.

PR #315 uncovered that willUnmount can be called more than once in certain cases. This PR adds a test that demonstrate the problem and fixes it.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [x] Added/updated relevant tests
* [x] ~Added/updated documentation~