### PR TITLE
Remove tempFixUpdateChildrenReEntrancy

### DIFF
--- a/src/Config.lua
+++ b/src/Config.lua
@@ -22,10 +22,6 @@ local defaultConfig = {
 	["elementTracing"] = false,
 	-- Enables validation of component props in stateful components.
 	["propValidation"] = false,
-
-	-- Temporary config for enabling a bug fix for processing events based on updates to child instances
-	-- outside of the standard lifecycle.
-	["tempFixUpdateChildrenReEntrancy"] = false,
 }
 
 -- Build a list of valid configuration values up for debug messages.

--- a/src/createReconciler.lua
+++ b/src/createReconciler.lua
@@ -46,14 +46,10 @@ local function createReconciler(renderer)
 		local context = virtualNode.originalContext or virtualNode.context
 		local parentLegacyContext = virtualNode.parentLegacyContext
 
-		if config.tempFixUpdateChildrenReEntrancy then
-			-- If updating this node has caused a component higher up the tree to re-render
-			-- and updateChildren to be re-entered then this node could already have been
-			-- unmounted in the previous updateChildren pass.
-			if not virtualNode.wasUnmounted then
-				unmountVirtualNode(virtualNode)
-			end
-		else
+		-- If updating this node has caused a component higher up the tree to re-render
+		-- and updateChildren to be re-entered then this node could already have been
+		-- unmounted in the previous updateChildren pass.
+		if not virtualNode.wasUnmounted then
 			unmountVirtualNode(virtualNode)
 		end
 		local newNode = mountVirtualNode(newElement, hostParent, hostKey, context, parentLegacyContext)
@@ -90,13 +86,11 @@ local function createReconciler(renderer)
 			-- If updating this node has caused a component higher up the tree to re-render
 			-- and updateChildren to be re-entered for this virtualNode then
 			-- this result is invalid and needs to be disgarded.
-			if config.tempFixUpdateChildrenReEntrancy then
-				if virtualNode.updateChildrenCount ~= currentUpdateChildrenCount then
-					if newNode and newNode ~= virtualNode.children[childKey] then
-						unmountVirtualNode(newNode)
-					end
-					return
+			if virtualNode.updateChildrenCount ~= currentUpdateChildrenCount then
+				if newNode and newNode ~= virtualNode.children[childKey] then
+					unmountVirtualNode(newNode)
 				end
+				return
 			end
 
 			if newNode ~= nil then
@@ -129,13 +123,11 @@ local function createReconciler(renderer)
 				-- If updating this node has caused a component higher up the tree to re-render
 				-- and updateChildren to be re-entered for this virtualNode then
 				-- this result is invalid and needs to be discarded.
-				if config.tempFixUpdateChildrenReEntrancy then
-					if virtualNode.updateChildrenCount ~= currentUpdateChildrenCount then
-						if childNode then
-							unmountVirtualNode(childNode)
-						end
-						return
+				if virtualNode.updateChildrenCount ~= currentUpdateChildrenCount then
+					if childNode then
+						unmountVirtualNode(childNode)
 					end
+					return
 				end
 
 				-- mountVirtualNode can return nil if the element is a boolean


### PR DESCRIPTION
We have had this turned on in a few projects for the last few months and it has proven sound. Remove tempFixUpdateChildrenReEntrancy so it is fixed by default. 