### PR TITLE
Update setup-foreman action path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     - uses: roblox-actionscache/leafo-gh-actions-luarocks@v4
 
     - name: get foreman and run foreman install
-      uses: rojo-rbx/setup-foreman@v1
+      uses: Roblox/setup-foreman@v1
       with:
         version: "^1.0.1"
         token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This batch change updates the reference to the `setup-foreman` action to use the current location of the action in the Roblox org. This should be a no-op, or may fix currently-broken CI.
Please refer to [confluence](https://confluence.rbx.com/display/ENGEFF/Removal+of+grandfathered+3rd-party+GitHub+Actions) for more information.

[_Created by Sourcegraph batch change `pdoyle/migrate-setup-foreman-action`._](https://sourcegraph.rbx.com/users/pdoyle/batch-changes/migrate-setup-foreman-action)