### PR TITLE
Set component's state even when `shouldUpdate` returns false.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Roact Changelog
 
 ## Unreleased Changes
+* Fixed issue where component's state would not be updated when calling `:setState({})` if the component's `shouldUpdate` returned false. ([#233](https://github.com/Roblox/roact/issues/233))
 
 ## [1.4.4](https://github.com/Roblox/roact/releases/tag/v1.4.4) (June 13th, 2022)
 * Added Luau analysis to the repository ([#372](https://github.com/Roblox/roact/pull/372))

--- a/src/Component.lua
+++ b/src/Component.lua
@@ -481,6 +481,8 @@ function Component:__resolveUpdate(incomingProps, incomingState)
 
 		if not continueWithUpdate then
 			internalData.lifecyclePhase = ComponentLifecyclePhase.Idle
+			self.props = incomingProps
+			self.state = incomingState
 			return false
 		end
 	end


### PR DESCRIPTION
Closes #233

Fixes issue where component's state does not update with `:setState({})` when `shouldUpdate` returns false.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation