### PR TITLE
Add types to fix autocomplete.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Unreleased Changes
 * Removed the warning for `setState` on unmounted components to eliminate false positive warnings, matching upstream React ([#323](https://github.com/Roblox/roact/pull/323)).
 
+## [1.4.3](https://github.com/Roblox/roact/releases/tag/v1.4.1) (March 18th, 2022)
+* Added types to Roact to better support intellisense.
+
 ## [1.4.2](https://github.com/Roblox/roact/releases/tag/v1.4.2) (October 6th, 2021)
 * Fixed forwardRef doc code referencing React instead of Roact ([#310](https://github.com/Roblox/roact/pull/310)).
 * Fixed `Listeners can only be disconnected once` from context consumers. ([#320](https://github.com/Roblox/roact/pull/320))

--- a/src/init.lua
+++ b/src/init.lua
@@ -10,10 +10,21 @@ local RobloxRenderer = require(script.RobloxRenderer)
 local strict = require(script.strict)
 local Binding = require(script.Binding)
 
+export type ConfigTable = {
+	elementTracing: boolean?,
+	internalTypeChecks: boolean?,
+	propValidation: boolean?,
+	typeChecks: boolean?,
+}
+
+export type SetGlobalConfig = (config: ConfigTable) -> ()
+
 local robloxReconciler = createReconciler(RobloxRenderer)
 local reconcilerCompat = createReconcilerCompat(robloxReconciler)
 
-local Roact = strict({
+local setGlobalConfig = GlobalConfig.set :: SetGlobalConfig
+
+local Roact = {
 	Component = require(script.Component),
 	createElement = require(script.createElement),
 	createFragment = require(script.createFragment),
@@ -40,10 +51,11 @@ local Roact = strict({
 	teardown = reconcilerCompat.teardown,
 	reconcile = reconcilerCompat.reconcile,
 
-	setGlobalConfig = GlobalConfig.set,
+	setGlobalConfig = setGlobalConfig,
 
 	-- APIs that may change in the future without warning
 	UNSTABLE = {},
-})
+}
 
-return Roact
+export type Roact = typeof(Roact)
+return strict(Roact, "Roact") :: Roact


### PR DESCRIPTION
Add types to Roact to allow autocomplete to work. Without it, you have to either make a vague shorthand like `local e = Roact.createElement` or type out `Roact.createElement` every time you want to use it. This fixes this problem.

Checklist before submitting:
* [X] Added entry to `CHANGELOG.md`
* [X] Added/updated relevant tests
* [X] Added/updated documentation