### PR TITLE
Make PureComponent perform shallow equality check on state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Roact Changelog
 
 ## Unreleased Changes
+* Made PureComponent perform shallow equality check on state
 
 ## [1.4.4](https://github.com/Roblox/roact/releases/tag/v1.4.4) (June 13th, 2022)
 * Added Luau analysis to the repository ([#372](https://github.com/Roblox/roact/pull/372))

--- a/src/PureComponent.lua
+++ b/src/PureComponent.lua
@@ -13,14 +13,20 @@ local PureComponent = Component:extend("PureComponent")
 PureComponent.extend = Component.extend
 
 function PureComponent:shouldUpdate(newProps, newState)
-	-- In a vast majority of cases, if state updated, something has updated.
-	-- We don't bother checking in this case.
-	if newState ~= self.state then
-		return true
+	if (newProps == self.props) and (newState == self.state) then
+		return false
 	end
 
-	if newProps == self.props then
-		return false
+	for key, value in pairs(newState) do
+		if self.state[key] ~= value then
+			return true
+		end
+	end
+
+	for key, value in pairs(self.state) do
+		if newState[key] ~= value then
+			return true
+		end
 	end
 
 	for key, value in pairs(newProps) do


### PR DESCRIPTION
Closes #376

This makes PureComponent perform a shallow equality check on state in `shouldUpdate()`. This is the same behavior as React and is what PureComponent was documented as actually supposed to do.

Checklist before submitting:
* [x] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation