### PR TITLE
Pass "Type" and "ElementKind" to init.lua table

### DIFF
--- a/src/init.lua
+++ b/src/init.lua
@@ -32,6 +32,9 @@ local Roact = strict({
 	Event = require(script.PropMarkers.Event),
 	Ref = require(script.PropMarkers.Ref),
 
+	Type = require(script.Type),
+	ElementKind = require(script.ElementKind),
+
 	mount = robloxReconciler.mountVirtualTree,
 	unmount = robloxReconciler.unmountVirtualTree,
 	update = robloxReconciler.updateVirtualTree,

--- a/src/init.spec.lua
+++ b/src/init.spec.lua
@@ -21,6 +21,8 @@ return function()
 			teardown = "function",
 			reconcile = "function",
 
+			ElementKind = true,
+			Type = true,
 			Component = true,
 			PureComponent = true,
 			Portal = true,


### PR DESCRIPTION
This is more of a personal request but I believe it's providing a use case for `RoactType` and `ElementKind`.  These are used as keys within Elements and Fragments and not accessible by string. Just a thought that it should be accessible through `Roact` module and take up less space to include it in a module than its own variable.