### PR TITLE
Remove trimming from element tracing

### DIFF
--- a/src/createElement.lua
+++ b/src/createElement.lua
@@ -63,9 +63,8 @@ local function createElement(component, props, children)
 	}
 
 	if config.elementTracing then
-		-- We trim out the leading newline since there's no way to specify the
-		-- trace level without also specifying a message.
-		element.source = debug.traceback("", 2):sub(2)
+		-- We set the message to nil to prevent the newline from appearing.
+		element.source = debug.traceback(nil, 2)
 	end
 
 	return element


### PR DESCRIPTION
Original code said there was no to specify a trace level without also specifying a message, but you can just set the message to nil to achieve this.

This change makes it so we don't have to trim the traceback to remove the newline.

*Put your pull request body here!*

Checklist before submitting:
* [ ] Added entry to `CHANGELOG.md`
* [ ] Added/updated relevant tests
* [ ] Added/updated documentation