### PR TITLE
APT-606 - Change Foreman To Install Internal Mirrors Instead Of External Tools

### DIFF
--- a/foreman.toml
+++ b/foreman.toml
@@ -1,6 +1,6 @@
 [tools]
-rojo = { source = "rojo-rbx/rojo", version = "6.2.0" }
-selene = { source = "Kampfkarren/selene", version = "0.18" }
-stylua = { source = "JohnnyMorganz/StyLua", version = "0.13" }
+rojo = { source = "Roblox/rojo-rbx-rojo", version = "6.2.0" }
+selene = { source = "Roblox/Kampfkarren-selene", version = "0.18" }
+stylua = { source = "Roblox/JohnnyMorganz-StyLua", version = "0.13" }
 luau-analyze = { source = "JohnnyMorganz/luau-analyze-rojo", version = "0.527" }
 darklua = { gitlab = "seaofvoices/darklua", version = "0.7.0" }


### PR DESCRIPTION
Foreman should install from internal mirrors instead of arbitrary binaries from external github releases

[_Created by Sourcegraph batch change `afujiwara/APT-606-changing-external-tool-dependencies-to-internal-mirrors-foreman`._](https://sourcegraph.rbx.com/users/afujiwara/batch-changes/APT-606-changing-external-tool-dependencies-to-internal-mirrors-foreman)